### PR TITLE
Feature 9: Implement property and profile base

### DIFF
--- a/.eslintrc.js
+++ b/.eslintrc.js
@@ -14,5 +14,6 @@ module.exports = {
     rules: {
         '@typescript-eslint/no-empty-function': 0,
         '@typescript-eslint/no-var-requires': 0,
+        '@typescript-eslint/no-inferrable-types': 0,
     },
 };

--- a/README.md
+++ b/README.md
@@ -69,7 +69,19 @@ Commands:
 
 ### Managing Properties
 
-### Examples
+```
+Usage: gradle-properties-manager-property [options] [command]
+
+Options:
+  -h, --help                   display help for command
+
+Commands:
+  set [options] [key] [value]  Add a new property with the given name
+  unset [options] [key]        Remove the entry for a given property key
+  get [options] [key]          Get the value associated with a given property key
+  ls [options]                 List all properties on a given profile
+  help [command]               display help for command
+```
 
 ## Shell Integration
 

--- a/README.md
+++ b/README.md
@@ -1,78 +1,92 @@
 # Gradle Properties Manager
 
-## About
-
 The globally available `~/.gradle/gradle.properties` is often used to alter values for a particular team or project within organizations. Manual management of this file is cumbersome, so this node module aims to ease that burden.
+
+-   [Gradle Properties Manager](#gradle-properties-manager)
+    -   [Installation](#installation)
+    -   [Usage](#usage)
+        -   [Initialization](#initialization)
+        -   [Managing Profiles](#managing-profiles)
+        -   [Examples](#examples)
+    -   [Shell Integration](#shell-integration)
+        -   [Powerlevel10k](#powerlevel10k)
 
 ## Installation
 
-`npm install -g gradle-properties-manager`
-
-OR
-
-`yarn global add gradle-properties-manager`
+```bash
+npm install -g gradle-properties-manager
+```
 
 ## Usage
 
-Executable available as `gradle-properties-manager` as well as `gpm`
+Executable available as `gradle-properties-manager`
 
-### Initializing the Properties Manager
+It's highly recommended, and will be assumed throughout this guide that you create an alias which points to it called `gpm`. To do this, you can add the following to your `~/.bashrc` or `~/.zshrc`:
 
-When first using the property manager, it's a good idea to back up your current `~/.gradle/gradle.properties` file. The `--init` flag will:
+```bash
+alias gpm='gradle-properties-manager'
+```
 
--   Backup your current `gradle.properties` file to `~/.gradle/gradle.properties.bak`
--   Create a `~/.gpm` folder where your profiles will be stored
+### Overview
+
+```
+Usage: gradle-properties-manager [options] [command]
+
+Options:
+  -h, --help      display help for command
+
+Commands:
+  profile         Manage profiles
+  property        Manage properties
+  init            Initialize gpm for first-time use
+  help [command]  display help for command
+```
+
+Run any of the above commands with the `--help` flag or as `gpm help <command>` for more info on usage
+
+### Initialization
+
+To start using gpm, first run `gpm init`
+
+You'll be taken through a series of prompts where you'll have the option to back up your current `~/.gradle/gradle.properties` file to `~/.gradle/gradle.properties.bak`, as well as move existing properties in your `gradle.properties` file over to gpm
 
 ### Managing Profiles
 
--   To create a profile:
-    `gpm --create-profile my-custom-profile`
+```
+Usage: gradle-properties-manager-profile [options] [command]
 
-_Note: The profile name is just an alias for the `.properties` file that it's stored in. Avoid using slashes or invalid filesystem characters in general for profile names_
+Get the name of the current profile
 
--   To list all available profiles:
-    `gpm --profiles`
+Options:
+  -h, --help     display help for command
 
--   To switch profiles:
-    `gpm --profile my-custom-profile`
+Commands:
+  create [name]  Add a new profile with the given name
+  set [name]     Switch to an existing profile
+  delete [name]  Remove an existing profile with the given name
+  ls             List all known profiles
+```
 
 ### Managing Properties
 
-When a property is added via the CLI, it's automatically added to whatever the current profile is set to:
-`gpm --property myspecialkey=myspecialvalue`
+### Examples
 
-In our case, this would set this property inside of our `my-custom-profile.properties` file inside of `~/.gpm`
+## Shell Integration
 
-If you'd like to add this property to the global profile, just add the `--global` flag when adding via the `--property` argument
+The name of the current profile is always available in `~/.gpm/profile`
 
-## Example Command Layout
+### Powerlevel10k
 
-> global.properties
-> nexusUrl=myspecialurl.com
+For an easy and immediate addition to your shell, you can add the following to your `~/.zshrc`:
 
-> colemeisterzpro.properties
-> // implicitly contains nexusUrl
-> nexusUsername=username
+```
+function prompt_my_gpm_profile() {
+    if [[ -e "$HOME/.gpm/profile" ]] ; then
+        # icon is unicode char 'e738' which is the java icon in nerd fonts
+        p10k segment -i '' -f 208 -t "$(cat ~/.gpm/profile)"
+    fi
+}
+POWERLEVEL9K_RIGHT_PROMPT_ELEMENTS+=my_gpm_profile
+```
 
-gpm profile // displays current profile
-
-gpm profile create <name> // create a profile with this name
-gpm profile delete <name> // prompts for confirmation of deletion
-gpm profile <name> // list info about one profile
-
-gpm profile ls // list all profiles
-
----
-
-gpm property ls --global --profile <profilename> // list all current properties on this profile
-
-gpm property set nexusUsername colemeister // <--- goes into profile
-gpm property set nexusUsername colemeister --global // <--- goes into global
-gpm property set nexusUsername --profile <profilename> // <-- set to specific profile
-gpm property set nexusPassword --secret // <-- triggers prompt and base64 encode
-
-gpm property unset nexusUsername --global --profile <profilename>
-
----
-
-gpm version
+However, if you'd like to change the order of your prompt element, you'll have to enter the `my_gpm_profile` signature into the appropriate location in your `~/.p10k.zsh` file's `POWERLEVEL9K_RIGHT_PROMPT_ELEMENTS` array

--- a/package-lock.json
+++ b/package-lock.json
@@ -594,6 +594,17 @@
         "rimraf": "^3.0.0",
         "slash": "^3.0.0",
         "strip-ansi": "^6.0.0"
+      },
+      "dependencies": {
+        "strip-ansi": {
+          "version": "6.0.0",
+          "resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-6.0.0.tgz",
+          "integrity": "sha512-AuvKTrTfQNYNIctbR1K/YGTR1756GycPsg7b9bdV9Duqur4gv6aKqHXah67Z8ImS7WEz5QVcOtlfW2rZEugt6w==",
+          "dev": true,
+          "requires": {
+            "ansi-regex": "^5.0.0"
+          }
+        }
       }
     },
     "@jest/environment": {
@@ -901,6 +912,12 @@
       "version": "2.0.0",
       "resolved": "https://registry.npmjs.org/@types/stack-utils/-/stack-utils-2.0.0.tgz",
       "integrity": "sha512-RJJrrySY7A8havqpGObOB4W92QXKJo63/jFLLgpvOtsGUqbQZ9Sbgl35KMm1DjC6j7AvmmU2bIno+3IyEaemaw==",
+      "dev": true
+    },
+    "@types/text-table": {
+      "version": "0.2.1",
+      "resolved": "https://registry.npmjs.org/@types/text-table/-/text-table-0.2.1.tgz",
+      "integrity": "sha512-dchbFCWfVgUSWEvhOkXGS7zjm+K7jCUvGrQkAHPk2Fmslfofp4HQTH2pqnQ3Pw5GPYv0zWa2AQjKtsfZThuemQ==",
       "dev": true
     },
     "@types/through": {
@@ -1543,6 +1560,17 @@
         "string-width": "^4.2.0",
         "strip-ansi": "^6.0.0",
         "wrap-ansi": "^6.2.0"
+      },
+      "dependencies": {
+        "strip-ansi": {
+          "version": "6.0.0",
+          "resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-6.0.0.tgz",
+          "integrity": "sha512-AuvKTrTfQNYNIctbR1K/YGTR1756GycPsg7b9bdV9Duqur4gv6aKqHXah67Z8ImS7WEz5QVcOtlfW2rZEugt6w==",
+          "dev": true,
+          "requires": {
+            "ansi-regex": "^5.0.0"
+          }
+        }
       }
     },
     "co": {
@@ -2011,6 +2039,17 @@
         "table": "^6.0.4",
         "text-table": "^0.2.0",
         "v8-compile-cache": "^2.0.3"
+      },
+      "dependencies": {
+        "strip-ansi": {
+          "version": "6.0.0",
+          "resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-6.0.0.tgz",
+          "integrity": "sha512-AuvKTrTfQNYNIctbR1K/YGTR1756GycPsg7b9bdV9Duqur4gv6aKqHXah67Z8ImS7WEz5QVcOtlfW2rZEugt6w==",
+          "dev": true,
+          "requires": {
+            "ansi-regex": "^5.0.0"
+          }
+        }
       }
     },
     "eslint-scope": {
@@ -2853,6 +2892,16 @@
         "string-width": "^4.1.0",
         "strip-ansi": "^6.0.0",
         "through": "^2.3.6"
+      },
+      "dependencies": {
+        "strip-ansi": {
+          "version": "6.0.0",
+          "resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-6.0.0.tgz",
+          "integrity": "sha512-AuvKTrTfQNYNIctbR1K/YGTR1756GycPsg7b9bdV9Duqur4gv6aKqHXah67Z8ImS7WEz5QVcOtlfW2rZEugt6w==",
+          "requires": {
+            "ansi-regex": "^5.0.0"
+          }
+        }
       }
     },
     "is-accessor-descriptor": {
@@ -3940,7 +3989,8 @@
     "mkdirp": {
       "version": "1.0.4",
       "resolved": "https://registry.npmjs.org/mkdirp/-/mkdirp-1.0.4.tgz",
-      "integrity": "sha512-vVqVZQyf3WLx2Shd0qJ9xuvqgAyKPLAiqITEtqW0oIUjzo3PePDd6fW9iFz30ef7Ysp/oiWqbhszeGWW2T6Gzw=="
+      "integrity": "sha512-vVqVZQyf3WLx2Shd0qJ9xuvqgAyKPLAiqITEtqW0oIUjzo3PePDd6fW9iFz30ef7Ysp/oiWqbhszeGWW2T6Gzw==",
+      "dev": true
     },
     "ms": {
       "version": "2.1.2",
@@ -4334,14 +4384,6 @@
       "requires": {
         "kleur": "^3.0.3",
         "sisteransi": "^1.0.5"
-      }
-    },
-    "properties-reader": {
-      "version": "2.2.0",
-      "resolved": "https://registry.npmjs.org/properties-reader/-/properties-reader-2.2.0.tgz",
-      "integrity": "sha512-CgVcr8MwGoBKK24r9TwHfZkLLaNFHQ6y4wgT9w/XzdpacOOi5ciH4hcuLechSDAwXsfrGQtI2JTutY2djOx2Ow==",
-      "requires": {
-        "mkdirp": "^1.0.4"
       }
     },
     "psl": {
@@ -5180,6 +5222,17 @@
       "requires": {
         "char-regex": "^1.0.2",
         "strip-ansi": "^6.0.0"
+      },
+      "dependencies": {
+        "strip-ansi": {
+          "version": "6.0.0",
+          "resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-6.0.0.tgz",
+          "integrity": "sha512-AuvKTrTfQNYNIctbR1K/YGTR1756GycPsg7b9bdV9Duqur4gv6aKqHXah67Z8ImS7WEz5QVcOtlfW2rZEugt6w==",
+          "dev": true,
+          "requires": {
+            "ansi-regex": "^5.0.0"
+          }
+        }
       }
     },
     "string-width": {
@@ -5190,6 +5243,16 @@
         "emoji-regex": "^8.0.0",
         "is-fullwidth-code-point": "^3.0.0",
         "strip-ansi": "^6.0.0"
+      },
+      "dependencies": {
+        "strip-ansi": {
+          "version": "6.0.0",
+          "resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-6.0.0.tgz",
+          "integrity": "sha512-AuvKTrTfQNYNIctbR1K/YGTR1756GycPsg7b9bdV9Duqur4gv6aKqHXah67Z8ImS7WEz5QVcOtlfW2rZEugt6w==",
+          "requires": {
+            "ansi-regex": "^5.0.0"
+          }
+        }
       }
     },
     "strip-ansi": {
@@ -5309,8 +5372,7 @@
     "text-table": {
       "version": "0.2.0",
       "resolved": "https://registry.npmjs.org/text-table/-/text-table-0.2.0.tgz",
-      "integrity": "sha1-f17oI66AUgfACvLfSoTsP8+lcLQ=",
-      "dev": true
+      "integrity": "sha1-f17oI66AUgfACvLfSoTsP8+lcLQ="
     },
     "throat": {
       "version": "5.0.0",
@@ -5725,6 +5787,17 @@
         "ansi-styles": "^4.0.0",
         "string-width": "^4.1.0",
         "strip-ansi": "^6.0.0"
+      },
+      "dependencies": {
+        "strip-ansi": {
+          "version": "6.0.0",
+          "resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-6.0.0.tgz",
+          "integrity": "sha512-AuvKTrTfQNYNIctbR1K/YGTR1756GycPsg7b9bdV9Duqur4gv6aKqHXah67Z8ImS7WEz5QVcOtlfW2rZEugt6w==",
+          "dev": true,
+          "requires": {
+            "ansi-regex": "^5.0.0"
+          }
+        }
       }
     },
     "wrappy": {

--- a/package-lock.json
+++ b/package-lock.json
@@ -1108,6 +1108,11 @@
         "picomatch": "^2.0.4"
       }
     },
+    "arg": {
+      "version": "4.1.3",
+      "resolved": "https://registry.npmjs.org/arg/-/arg-4.1.3.tgz",
+      "integrity": "sha512-58S9QDqG0Xx27YwPSt9fJxivjYl432YCwfDMfZ+71RAqUrZef7LrKQZ3LHLOwCS4FLNBplP533Zx895SeOCHvA=="
+    },
     "argparse": {
       "version": "1.0.10",
       "resolved": "https://registry.npmjs.org/argparse/-/argparse-1.0.10.tgz",
@@ -1394,8 +1399,7 @@
     "buffer-from": {
       "version": "1.1.1",
       "resolved": "https://registry.npmjs.org/buffer-from/-/buffer-from-1.1.1.tgz",
-      "integrity": "sha512-MQcXEUbCKtEo7bhqEs6560Hyd4XaovZlO/k9V3hjVUF/zwW7KBVdSK4gIt/bzwS9MbR5qob+F5jusZsb0YQK2A==",
-      "dev": true
+      "integrity": "sha512-MQcXEUbCKtEo7bhqEs6560Hyd4XaovZlO/k9V3hjVUF/zwW7KBVdSK4gIt/bzwS9MbR5qob+F5jusZsb0YQK2A=="
     },
     "cache-base": {
       "version": "1.0.1",
@@ -1628,6 +1632,11 @@
       "integrity": "sha1-tf1UIgqivFq1eqtxQMlAdUUDwac=",
       "dev": true
     },
+    "create-require": {
+      "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/create-require/-/create-require-1.1.1.tgz",
+      "integrity": "sha512-dcKFX3jn0MpIaXjisoRvexIJVEKzaq7z2rZKxf+MSr9TkdmHmsU4m2lcLojrj/FHl8mk5VxMmYA+ftRkP/3oKQ=="
+    },
     "cross-spawn": {
       "version": "7.0.3",
       "resolved": "https://registry.npmjs.org/cross-spawn/-/cross-spawn-7.0.3.tgz",
@@ -1788,6 +1797,11 @@
       "resolved": "https://registry.npmjs.org/detect-newline/-/detect-newline-3.1.0.tgz",
       "integrity": "sha512-TLz+x/vEXm/Y7P7wn1EJFNLxYpUD4TgMosxY6fAVJUnJMbupHBOncxyWUG9OpTaH9EBD7uFI5LfEgmMOc54DsA==",
       "dev": true
+    },
+    "diff": {
+      "version": "4.0.2",
+      "resolved": "https://registry.npmjs.org/diff/-/diff-4.0.2.tgz",
+      "integrity": "sha512-58lmxKSA4BNyLz+HHMUzlOEpg09FV+ev6ZMe3vJihgdxzgcwZ8VoEEPmALCZG9LmqfVoNMMKpttIYTVG6uDY7A=="
     },
     "diff-sequences": {
       "version": "26.6.2",
@@ -3822,8 +3836,7 @@
     "make-error": {
       "version": "1.3.6",
       "resolved": "https://registry.npmjs.org/make-error/-/make-error-1.3.6.tgz",
-      "integrity": "sha512-s8UhlNe7vPKomQhC1qFelMokr/Sc3AgNbso3n74mVPA5LTZwkB9NlXf4XPamLxJE8h0gh73rM94xvwRT2CVInw==",
-      "dev": true
+      "integrity": "sha512-s8UhlNe7vPKomQhC1qFelMokr/Sc3AgNbso3n74mVPA5LTZwkB9NlXf4XPamLxJE8h0gh73rM94xvwRT2CVInw=="
     },
     "makeerror": {
       "version": "1.0.11",
@@ -5014,8 +5027,7 @@
     "source-map": {
       "version": "0.6.1",
       "resolved": "https://registry.npmjs.org/source-map/-/source-map-0.6.1.tgz",
-      "integrity": "sha512-UjgapumWlbMhkBgzT7Ykc5YXUT46F0iKu8SGXq0bcwP5dz/h0Plj6enJqjz1Zbq2l5WaqYnrVbwWOWMyF3F47g==",
-      "dev": true
+      "integrity": "sha512-UjgapumWlbMhkBgzT7Ykc5YXUT46F0iKu8SGXq0bcwP5dz/h0Plj6enJqjz1Zbq2l5WaqYnrVbwWOWMyF3F47g=="
     },
     "source-map-resolve": {
       "version": "0.5.3",
@@ -5034,7 +5046,6 @@
       "version": "0.5.19",
       "resolved": "https://registry.npmjs.org/source-map-support/-/source-map-support-0.5.19.tgz",
       "integrity": "sha512-Wonm7zOCIJzBGQdB+thsPar0kYuCIzYvxZwlBa87yi/Mdjv7Tip2cyVbLj5o0cFPN4EVkuTwb3GDDyUx2DGnGw==",
-      "dev": true,
       "requires": {
         "buffer-from": "^1.0.0",
         "source-map": "^0.6.0"
@@ -5411,6 +5422,19 @@
         }
       }
     },
+    "ts-node": {
+      "version": "9.1.1",
+      "resolved": "https://registry.npmjs.org/ts-node/-/ts-node-9.1.1.tgz",
+      "integrity": "sha512-hPlt7ZACERQGf03M253ytLY3dHbGNGrAq9qIHWUY9XHYl1z7wYngSr3OQ5xmui8o2AaxsONxIzjafLUiWBo1Fg==",
+      "requires": {
+        "arg": "^4.1.0",
+        "create-require": "^1.1.0",
+        "diff": "^4.0.1",
+        "make-error": "^1.1.1",
+        "source-map-support": "^0.5.17",
+        "yn": "3.1.1"
+      }
+    },
     "tslib": {
       "version": "1.14.1",
       "resolved": "https://registry.npmjs.org/tslib/-/tslib-1.14.1.tgz",
@@ -5771,6 +5795,11 @@
         "camelcase": "^5.0.0",
         "decamelize": "^1.2.0"
       }
+    },
+    "yn": {
+      "version": "3.1.1",
+      "resolved": "https://registry.npmjs.org/yn/-/yn-3.1.1.tgz",
+      "integrity": "sha512-Ux4ygGWsu2c7isFWe8Yu1YluJmqVhxqK2cLXNQA5AcC3QfbGNpM7fu0Y8b/z16pXLnFxZYvWhd3fhBY9DLmC6Q=="
     }
   }
 }

--- a/package-lock.json
+++ b/package-lock.json
@@ -3940,8 +3940,7 @@
     "mkdirp": {
       "version": "1.0.4",
       "resolved": "https://registry.npmjs.org/mkdirp/-/mkdirp-1.0.4.tgz",
-      "integrity": "sha512-vVqVZQyf3WLx2Shd0qJ9xuvqgAyKPLAiqITEtqW0oIUjzo3PePDd6fW9iFz30ef7Ysp/oiWqbhszeGWW2T6Gzw==",
-      "dev": true
+      "integrity": "sha512-vVqVZQyf3WLx2Shd0qJ9xuvqgAyKPLAiqITEtqW0oIUjzo3PePDd6fW9iFz30ef7Ysp/oiWqbhszeGWW2T6Gzw=="
     },
     "ms": {
       "version": "2.1.2",
@@ -4335,6 +4334,14 @@
       "requires": {
         "kleur": "^3.0.3",
         "sisteransi": "^1.0.5"
+      }
+    },
+    "properties-reader": {
+      "version": "2.2.0",
+      "resolved": "https://registry.npmjs.org/properties-reader/-/properties-reader-2.2.0.tgz",
+      "integrity": "sha512-CgVcr8MwGoBKK24r9TwHfZkLLaNFHQ6y4wgT9w/XzdpacOOi5ciH4hcuLechSDAwXsfrGQtI2JTutY2djOx2Ow==",
+      "requires": {
+        "mkdirp": "^1.0.4"
       }
     },
     "psl": {

--- a/package.json
+++ b/package.json
@@ -31,7 +31,6 @@
         "del": "^6.0.0",
         "esm": "^3.2.25",
         "inquirer": "^8.0.0",
-        "properties-reader": "^2.2.0",
         "ts-node": "^9.1.1",
         "uuid": "^8.3.2"
     },

--- a/package.json
+++ b/package.json
@@ -22,7 +22,8 @@
         "dev": "tsc --project tsconfig.build.json -w",
         "compile": "tsc --project tsconfig.build.json ",
         "test": "jest --watch",
-        "test:ci": "CI=true jest"
+        "test:ci": "CI=true jest",
+        "clean": "ts-node scripts/clean-gpm-files.ts"
     },
     "dependencies": {
         "chalk": "^4.1.0",
@@ -30,6 +31,7 @@
         "del": "^6.0.0",
         "esm": "^3.2.25",
         "inquirer": "^8.0.0",
+        "ts-node": "^9.1.1",
         "uuid": "^8.3.2"
     },
     "devDependencies": {

--- a/package.json
+++ b/package.json
@@ -31,10 +31,13 @@
         "del": "^6.0.0",
         "esm": "^3.2.25",
         "inquirer": "^8.0.0",
+        "strip-ansi": "^6.0.0",
+        "text-table": "^0.2.0",
         "ts-node": "^9.1.1",
         "uuid": "^8.3.2"
     },
     "devDependencies": {
+        "@types/text-table": "^0.2.1",
         "@types/inquirer": "^7.3.1",
         "@types/jest": "^26.0.22",
         "@types/node": "^14.14.37",

--- a/package.json
+++ b/package.json
@@ -31,6 +31,7 @@
         "del": "^6.0.0",
         "esm": "^3.2.25",
         "inquirer": "^8.0.0",
+        "properties-reader": "^2.2.0",
         "ts-node": "^9.1.1",
         "uuid": "^8.3.2"
     },

--- a/scripts/clean-gpm-files.ts
+++ b/scripts/clean-gpm-files.ts
@@ -37,7 +37,7 @@ const promptDirectoryRemoval = async (directory: string) => {
 };
 
 const main = async (): Promise<void> => {
-    await promptDirectoryRemoval(constants.GPM_HOME_DIRECTORY_LOCATION);
+    await promptDirectoryRemoval(constants.GPM_HOME_PATH);
     await promptFileRemoval(constants.GRADLE_PROPERTIES_FILE_LOCATION);
     await promptFileRemoval(constants.GRADLE_PROPERTIES_BAK_FILE_LOCATION);
 };

--- a/scripts/clean-gpm-files.ts
+++ b/scripts/clean-gpm-files.ts
@@ -6,14 +6,16 @@ const promptFileRemoval = async (file: string) => {
     const { remove } = await inquirer.prompt([
         {
             type: 'confirm',
-            name: 'backup',
+            name: 'remove',
             message: `Remove file '${file}'?`,
             default: false,
         },
     ]);
 
     if (remove) {
-        fs.unlinkSync(file);
+        if (fs.existsSync(file)) {
+            fs.unlinkSync(file);
+        }
     }
 };
 
@@ -21,14 +23,16 @@ const promptDirectoryRemoval = async (directory: string) => {
     const { remove } = await inquirer.prompt([
         {
             type: 'confirm',
-            name: 'backup',
+            name: 'remove',
             message: `Remove directory '${directory}' and all of it's content?`,
             default: false,
         },
     ]);
 
     if (remove) {
-        fs.rmdirSync(directory, { recursive: true });
+        if (fs.existsSync(directory)) {
+            fs.rmdirSync(directory, { recursive: true });
+        }
     }
 };
 

--- a/scripts/clean-gpm-files.ts
+++ b/scripts/clean-gpm-files.ts
@@ -1,0 +1,41 @@
+import fs from 'fs';
+import inquirer from 'inquirer';
+import * as constants from '../src/constants';
+
+const promptFileRemoval = async (file: string) => {
+    const { remove } = await inquirer.prompt([
+        {
+            type: 'confirm',
+            name: 'backup',
+            message: `Remove file '${file}'?`,
+            default: false,
+        },
+    ]);
+
+    if (remove) {
+        fs.unlinkSync(file);
+    }
+};
+
+const promptDirectoryRemoval = async (directory: string) => {
+    const { remove } = await inquirer.prompt([
+        {
+            type: 'confirm',
+            name: 'backup',
+            message: `Remove directory '${directory}' and all of it's content?`,
+            default: false,
+        },
+    ]);
+
+    if (remove) {
+        fs.rmdirSync(directory, { recursive: true });
+    }
+};
+
+const main = async (): Promise<void> => {
+    await promptDirectoryRemoval(constants.GPM_HOME_DIRECTORY_LOCATION);
+    await promptFileRemoval(constants.GRADLE_PROPERTIES_FILE_LOCATION);
+    await promptFileRemoval(constants.GRADLE_PROPERTIES_BAK_FILE_LOCATION);
+};
+
+main();

--- a/src/cli.ts
+++ b/src/cli.ts
@@ -1,8 +1,14 @@
 import { Command } from 'commander';
+import { handleInit } from './commands/init';
 
 const program = new Command();
 
-program.command('profile', 'Manange profiles');
+program.command('profile', 'Manage profiles');
 program.command('property', 'Manage properties');
+
+program
+    .command('init')
+    .description('Initialize gpm for first-time use')
+    .action(handleInit);
 
 program.parse(process.argv);

--- a/src/commands/init.ts
+++ b/src/commands/init.ts
@@ -66,12 +66,6 @@ const backupExistingPropertiesFile = async (): Promise<void> => {
         } else {
             console.log(BACKUP_CREATED);
         }
-
-        fs.writeFileSync(
-            constants.GRADLE_PROPERTIES_FILE_LOCATION,
-            constants.GPM_ANNOTATION,
-            { encoding: 'utf-8' }
-        );
     }
 };
 
@@ -108,6 +102,13 @@ export const handleInit = async (): Promise<void> => {
     if (fs.existsSync(constants.GRADLE_PROPERTIES_FILE_LOCATION)) {
         await backupExistingPropertiesFile();
     }
+
+    // Create gpm-controlled gradle.properties file
+    fs.writeFileSync(
+        constants.GRADLE_PROPERTIES_FILE_LOCATION,
+        constants.GPM_ANNOTATION,
+        { encoding: 'utf-8' }
+    );
 
     fs.mkdirSync(constants.GPM_HOME_PATH);
     await createInitialProfile();

--- a/src/commands/init.ts
+++ b/src/commands/init.ts
@@ -1,0 +1,97 @@
+import fs from 'fs';
+
+import * as constants from '../constants';
+
+import chalk from 'chalk';
+import inquirer from 'inquirer';
+
+const BACKUP_PROPERTIES =
+    chalk.yellow('[WARN]') +
+    ` File '${constants.GRADLE_PROPERTIES_FILE_NAME}' already exists, would you like to \
+create a backup at '${constants.GRADLE_PROPERTIES_FILE_NAME}.bak'?`;
+
+const ALREADY_INITIALIZED = chalk.red(
+    "You've already initialized gradle-properties-manager..."
+);
+
+const BACKUP_FAILED = chalk.red(
+    `Failed to backup existing '${constants.GRADLE_PROPERTIES_FILE_NAME}'...`
+);
+
+const BACKUP_ALREADY_EXISTS = chalk.red(
+    `Backup file '${constants.GRADLE_PROPERTIES_BAK_FILE_NAME}' already exists...`
+);
+
+const BACKUP_CREATED = chalk.green(
+    `Successfully backed up '${constants.GRADLE_PROPERTIES_FILE_NAME}' to '${constants.GRADLE_PROPERTIES_BAK_FILE_NAME}'...`
+);
+
+const backup = async (): Promise<void> => {};
+
+const handleExistingProperties = async (): Promise<void> => {
+    const { backup } = await inquirer.prompt([
+        {
+            type: 'confirm',
+            name: 'backup',
+            message: BACKUP_PROPERTIES,
+        },
+    ]);
+
+    if (backup) {
+        if (fs.existsSync(constants.GRADLE_PROPERTIES_BAK_FILE_LOCATION)) {
+            console.log(BACKUP_ALREADY_EXISTS);
+        }
+
+        fs.copyFileSync(
+            constants.GRADLE_PROPERTIES_FILE_LOCATION,
+            constants.GRADLE_PROPERTIES_BAK_FILE_LOCATION
+        );
+
+        if (!fs.existsSync(constants.GRADLE_PROPERTIES_BAK_FILE_LOCATION)) {
+            console.log(BACKUP_FAILED);
+            process.exit(1);
+        } else {
+            console.log(BACKUP_CREATED);
+        }
+
+        fs.writeFileSync(
+            constants.GRADLE_PROPERTIES_FILE_LOCATION,
+            constants.GPM_ANNOTATION,
+            { encoding: 'utf-8' }
+        );
+    }
+};
+
+const gpmInitialized = (): boolean => {
+    const gradlePropertiesFileContent = fs.readFileSync(
+        constants.GRADLE_PROPERTIES_FILE_LOCATION,
+        'utf-8'
+    );
+
+    if (gradlePropertiesFileContent.includes(constants.GPM_ANNOTATION)) {
+        return true;
+    }
+
+    return false;
+};
+
+export const handleInit = async (): Promise<void> => {
+    // - check if there's an existing gradle.properties in ~/.gradle
+    // - if there is, check if its gpm controlled, otherwise prompt to
+    // confirm backup location of: ~/.gradle/gradle.properties.bak
+    // - create new gradle.properties file with annotation that
+    // indicates it is now gpm controlled (//@gpm)
+    // - create ~/.gpm home directory
+    // - ask if they'd like to move any existing properties to the global scope
+    // - prompt for profile name?? [default]
+    // - ask if they'd like to move any properties to this profile
+
+    console.log(constants.GRADLE_PROPERTIES_FILE_LOCATION);
+    if (fs.existsSync(constants.GRADLE_PROPERTIES_FILE_LOCATION)) {
+        if (gpmInitialized()) {
+            console.log(ALREADY_INITIALIZED);
+            process.exit(1);
+        }
+        handleExistingProperties();
+    }
+};

--- a/src/commands/init.ts
+++ b/src/commands/init.ts
@@ -109,10 +109,7 @@ export const handleInit = async (): Promise<void> => {
         await backupExistingPropertiesFile();
     }
 
-    fs.mkdirSync(constants.GPM_HOME_DIRECTORY_LOCATION);
+    fs.mkdirSync(constants.GPM_HOME_PATH);
     await createInitialProfile();
     common.createGlobalProfile();
-
-    // console.log('Current profile:', getCurrentProfileName());
-    // console.log('All profiles:', getAllProfiles());
 };

--- a/src/commands/init.ts
+++ b/src/commands/init.ts
@@ -106,11 +106,11 @@ export const handleInit = async (): Promise<void> => {
     // Create gpm-controlled gradle.properties file
     fs.writeFileSync(
         constants.GRADLE_PROPERTIES_FILE_LOCATION,
-        constants.GPM_ANNOTATION,
+        `${constants.GPM_ANNOTATION}\n${constants.GPM_API_VERSION_ANNOTATION}`,
         { encoding: 'utf-8' }
     );
 
     fs.mkdirSync(constants.GPM_HOME_PATH);
-    await createInitialProfile();
     common.createGlobalProfile();
+    await createInitialProfile();
 };

--- a/src/commands/init.ts
+++ b/src/commands/init.ts
@@ -1,13 +1,7 @@
 import fs from 'fs';
 
 import * as constants from '../constants';
-import {
-    createGlobalProfile,
-    createProfile,
-    getAllProfiles,
-    getCurrentProfileName,
-    setProfile,
-} from '../common';
+import * as common from '../common';
 
 import chalk from 'chalk';
 import inquirer from 'inquirer';
@@ -81,33 +75,6 @@ const backupExistingPropertiesFile = async (): Promise<void> => {
     }
 };
 
-const gpmInitialized = (): boolean => {
-    // TODO: Account for incomplete initialization. For example,
-    // if the .gpm home directory has been created, that doesn't
-    // necessarily mean there's an active profile and respective
-    // gpm-controlled gradle.properties file
-
-    if (fs.existsSync(constants.GPM_HOME_DIRECTORY_LOCATION)) {
-        return true;
-    }
-
-    let gradlePropertiesFileContent: string;
-    if (fs.existsSync(constants.GRADLE_PROPERTIES_FILE_LOCATION)) {
-        gradlePropertiesFileContent = fs.readFileSync(
-            constants.GRADLE_PROPERTIES_FILE_LOCATION,
-            'utf-8'
-        );
-    } else {
-        return false;
-    }
-
-    if (gradlePropertiesFileContent.includes(constants.GPM_ANNOTATION)) {
-        return true;
-    }
-
-    return false;
-};
-
 const createInitialProfile = async (): Promise<void> => {
     const { name } = await inquirer.prompt([
         {
@@ -118,8 +85,8 @@ const createInitialProfile = async (): Promise<void> => {
         },
     ]);
 
-    createProfile(name);
-    setProfile(name);
+    common.createProfile(name);
+    common.setProfile(name);
 };
 
 export const handleInit = async (): Promise<void> => {
@@ -133,7 +100,7 @@ export const handleInit = async (): Promise<void> => {
     // - prompt for profile name?? [default]
     // - ask if they'd like to move any properties to this profile
 
-    if (gpmInitialized()) {
+    if (common.gpmInitialized()) {
         console.log(ALREADY_INITIALIZED);
         process.exit(1);
     }
@@ -144,7 +111,7 @@ export const handleInit = async (): Promise<void> => {
 
     fs.mkdirSync(constants.GPM_HOME_DIRECTORY_LOCATION);
     await createInitialProfile();
-    createGlobalProfile();
+    common.createGlobalProfile();
 
     // console.log('Current profile:', getCurrentProfileName());
     // console.log('All profiles:', getAllProfiles());

--- a/src/commands/profile.ts
+++ b/src/commands/profile.ts
@@ -7,11 +7,21 @@ const program = new Command();
 program
     .command('create [name]')
     .description('Add a new profile with the given name')
-    .action((name: string) => {
+    .action(async (name: string) => {
         common.assertGpmInitialized();
-        common.assertNotNullOrEmpty(name, 'name');
 
-        common.createProfile(name);
+        name = await common.resolveArg(name, 'name');
+        common.createProfile(name, true);
+        common.setProfile(name, true);
+    });
+
+program
+    .command('set [name]')
+    .description('Switch to an existing profile')
+    .action(async (name: string) => {
+        common.assertGpmInitialized();
+
+        name = await common.resolveArg(name, 'name');
         common.setProfile(name, true);
     });
 
@@ -20,7 +30,6 @@ program
     .description('Remove an existing profile with the given name')
     .action((name: string) => {
         common.assertGpmInitialized();
-        common.assertNotNullOrEmpty(name, 'name');
 
         common.deleteProfile(name, true);
     });

--- a/src/commands/profile.ts
+++ b/src/commands/profile.ts
@@ -31,6 +31,8 @@ program
     .action((name: string) => {
         common.assertGpmInitialized();
 
+        // TODO: Add in a confirmation prompt to this (with a --force flag
+        // option in order to not be prompted)
         common.deleteProfile(name, true);
     });
 

--- a/src/commands/profile.ts
+++ b/src/commands/profile.ts
@@ -1,37 +1,43 @@
 import chalk from 'chalk';
 import { Command } from 'commander';
+import * as common from '../common';
 
 const program = new Command();
 
 program
     .command('create [name]')
     .description('Add a new profile with the given name')
-    .action((name, options) => {
-        console.log(chalk.green('beep boop adding profile:', name));
+    .action((name) => {
+        common.assertGpmInitialized();
+        common.assertDefined(name, 'name');
 
-        /*
-        - Check if profile exists
-        - If not, create it and let the user know the current profile
-        will be switched to this one
-        - Prompt the user for any properties they'd like to add
-        (should be a continuous interactive prompt that they
-        must exit from)
-    */
+        common.createProfile(name);
+        common.setProfile(name, true);
     });
 
 program
     .command('delete [name]')
     .description('Remove an existing profile with the given name')
-    .action((name, options) => {});
+    .action((name) => {
+        common.assertGpmInitialized();
+        common.assertDefined(name, 'name');
 
-program
-    .command('describe [name]')
-    .description('Describe a profile')
-    .action((options) => {});
+        common.deleteProfile(name, true);
+    });
 
 program
     .command('ls')
     .description('List all known profiles')
-    .action((options) => {});
+    .action(() => {
+        common.assertGpmInitialized();
+
+        common.listAllProfiles();
+    });
+
+program.action(() => {
+    common.assertGpmInitialized();
+
+    console.log(common.getCurrentProfileName());
+});
 
 program.parse(process.argv);

--- a/src/commands/profile.ts
+++ b/src/commands/profile.ts
@@ -34,10 +34,12 @@ program
         common.listAllProfiles();
     });
 
-program.action(() => {
-    common.assertGpmInitialized();
+program
+    .action(() => {
+        common.assertGpmInitialized();
 
-    console.log(common.getCurrentProfileName());
-});
+        console.log(common.getCurrentProfileName());
+    })
+    .description('Get the name of the current profile');
 
 program.parse(process.argv);

--- a/src/commands/profile.ts
+++ b/src/commands/profile.ts
@@ -7,9 +7,9 @@ const program = new Command();
 program
     .command('create [name]')
     .description('Add a new profile with the given name')
-    .action((name) => {
+    .action((name: string) => {
         common.assertGpmInitialized();
-        common.assertDefined(name, 'name');
+        common.assertNotNullOrEmpty(name, 'name');
 
         common.createProfile(name);
         common.setProfile(name, true);
@@ -18,9 +18,9 @@ program
 program
     .command('delete [name]')
     .description('Remove an existing profile with the given name')
-    .action((name) => {
+    .action((name: string) => {
         common.assertGpmInitialized();
-        common.assertDefined(name, 'name');
+        common.assertNotNullOrEmpty(name, 'name');
 
         common.deleteProfile(name, true);
     });

--- a/src/commands/property.ts
+++ b/src/commands/property.ts
@@ -1,9 +1,9 @@
-import chalk from 'chalk';
-import { Command, Option } from 'commander';
-import inquirer from 'inquirer';
-import { PropertiesFile } from '../properties/properties-types';
+import { Command } from 'commander';
+
 import { handleSet } from './property/set-cli';
 import { handleGet } from './property/get-cli';
+import { handleUnset } from './property/unset-cli';
+import { handleLs } from './property/ls-cli';
 import * as common from '../common';
 
 const program = new Command();
@@ -42,7 +42,7 @@ program
         'Removes the property to a specific profile, ignoring the current one',
         common.getCurrentProfileName()
     )
-    .action((key) => {});
+    .action(handleUnset);
 
 program
     .command('get [key]')
@@ -58,7 +58,7 @@ program
     )
     .option(
         '-d, --decode',
-        'Decodes the property if it was a secret, NOOP otherwise',
+        'Decodes the property if it was a secret, NOP otherwise',
         false
     )
     .description('Get the value associated with a given property key')
@@ -69,8 +69,7 @@ program
     .description('List all properties on a given profile')
     .option(
         '-g, --global',
-        'Saves the property to the global properties scope. \
-This will be shared across all profiles',
+        'The list will include properties in the global scope',
         false
     )
     .option(
@@ -78,6 +77,6 @@ This will be shared across all profiles',
         'Saves the property to a specific profile, ignoring the current one',
         common.getCurrentProfileName()
     )
-    .action((options) => {});
+    .action(handleLs);
 
 program.parse(process.argv);

--- a/src/commands/property.ts
+++ b/src/commands/property.ts
@@ -1,6 +1,7 @@
 import chalk from 'chalk';
 import { Command, Option } from 'commander';
 import inquirer from 'inquirer';
+import { PropertiesFile } from '../properties/properties';
 import { handleSet } from './property/set-cli';
 
 const program = new Command();
@@ -26,7 +27,11 @@ This will be shared across all profiles'
 program
     .command('unset [key]')
     .description('Remove the entry for a given property key')
-    .action((name, options) => {});
+    .action((name, options) => {
+        const props = '/home/abadran/test-gradle-project/gradle.properties';
+        const file: PropertiesFile = new PropertiesFile(props);
+        file.load();
+    });
 
 program
     .command('get [key]')

--- a/src/commands/property.ts
+++ b/src/commands/property.ts
@@ -12,8 +12,8 @@ program
     .command('set [key] [value]')
     .description('Add a new property with the given name')
     .option(
-        '-s, --secret',
-        'User will be silently prompted for the value, and it will be base64 encoded',
+        '-e, --encode',
+        'Property will be base64 encoded. If the value is omitted, user will be silently prompted',
         false
     )
     .option(

--- a/src/commands/property.ts
+++ b/src/commands/property.ts
@@ -12,7 +12,12 @@ program
     .command('set [key] [value]')
     .description('Add a new property with the given name')
     .option(
-        '-e, --encode',
+        '-e, --encoded',
+        'Property will be base64 encoded. If the value is omitted, user will be silently prompted',
+        false
+    )
+    .option(
+        '-m, --masked',
         'Property will be base64 encoded. If the value is omitted, user will be silently prompted',
         false
     )
@@ -59,6 +64,11 @@ program
     .option(
         '-d, --decode',
         'Decodes the property if it was a secret, NOP otherwise',
+        false
+    )
+    .option(
+        '-u, --unmask',
+        'Unmasks the property if it was masked, NOP otherwise',
         false
     )
     .description('Get the value associated with a given property key')

--- a/src/commands/property.ts
+++ b/src/commands/property.ts
@@ -1,7 +1,7 @@
 import chalk from 'chalk';
 import { Command, Option } from 'commander';
 import inquirer from 'inquirer';
-import { PropertiesFile } from '../properties/properties';
+import { PropertiesFile } from '../properties/properties-types';
 import { handleSet } from './property/set-cli';
 import { handleGet } from './property/get-cli';
 import * as common from '../common';
@@ -10,7 +10,7 @@ const program = new Command();
 
 program
     .command('set [key] [value]')
-    .description('Add a new profile with the given name')
+    .description('Add a new property with the given name')
     .option(
         '-s, --secret',
         'User will be silently prompted for the value, and it will be base64 encoded',
@@ -32,6 +32,16 @@ This will be shared across all profiles',
 program
     .command('unset [key]')
     .description('Remove the entry for a given property key')
+    .option(
+        '-g, --global',
+        'Removes the property to the global properties scope',
+        false
+    )
+    .option(
+        '-p, --profile [name]',
+        'Removes the property to a specific profile, ignoring the current one',
+        common.getCurrentProfileName()
+    )
     .action((key) => {});
 
 program
@@ -42,7 +52,7 @@ program
         false
     )
     .option(
-        '-p, --profile [name]',
+        '-p, --profile <name>',
         'Saves the property to a specific profile, ignoring the current one',
         common.getCurrentProfileName()
     )
@@ -56,7 +66,18 @@ program
 
 program
     .command('ls')
-    .description('List all properties on a profile')
+    .description('List all properties on a given profile')
+    .option(
+        '-g, --global',
+        'Saves the property to the global properties scope. \
+This will be shared across all profiles',
+        false
+    )
+    .option(
+        '-p, --profile [name]',
+        'Saves the property to a specific profile, ignoring the current one',
+        common.getCurrentProfileName()
+    )
     .action((options) => {});
 
 program.parse(process.argv);

--- a/src/commands/property.ts
+++ b/src/commands/property.ts
@@ -14,7 +14,12 @@ program
     )
     .option(
         '-g, --global',
-        'Sets the property to the shared, global properties scope. This will be shared across all profiles'
+        'Saves the property to the global properties scope. \
+This will be shared across all profiles'
+    )
+    .option(
+        '-p, --profile',
+        'Saves the property to a specific profile, ignoring the current one'
     )
     .action(handleSet);
 

--- a/src/commands/property.ts
+++ b/src/commands/property.ts
@@ -3,6 +3,8 @@ import { Command, Option } from 'commander';
 import inquirer from 'inquirer';
 import { PropertiesFile } from '../properties/properties';
 import { handleSet } from './property/set-cli';
+import { handleGet } from './property/get-cli';
+import * as common from '../common';
 
 const program = new Command();
 
@@ -11,36 +13,50 @@ program
     .description('Add a new profile with the given name')
     .option(
         '-s, --secret',
-        'User will be prompted in silent mode for the property value'
+        'User will be silently prompted for the value, and it will be base64 encoded',
+        false
     )
     .option(
         '-g, --global',
         'Saves the property to the global properties scope. \
-This will be shared across all profiles'
+This will be shared across all profiles',
+        false
     )
     .option(
-        '-p, --profile',
-        'Saves the property to a specific profile, ignoring the current one'
+        '-p, --profile [name]',
+        'Saves the property to a specific profile, ignoring the current one',
+        common.getCurrentProfileName()
     )
     .action(handleSet);
 
 program
     .command('unset [key]')
     .description('Remove the entry for a given property key')
-    .action((name, options) => {
-        const props = '/home/abadran/test-gradle-project/gradle.properties';
-        const file: PropertiesFile = new PropertiesFile(props);
-        file.load();
-    });
+    .action((key) => {});
 
 program
     .command('get [key]')
+    .option(
+        '-g, --global',
+        'Retrieves the property from the global scope',
+        false
+    )
+    .option(
+        '-p, --profile [name]',
+        'Saves the property to a specific profile, ignoring the current one',
+        common.getCurrentProfileName()
+    )
+    .option(
+        '-d, --decode',
+        'Decodes the property if it was a secret, NOOP otherwise',
+        false
+    )
     .description('Get the value associated with a given property key')
-    .action((options) => {});
+    .action(handleGet);
 
 program
     .command('ls')
-    .description('List all known profiles')
+    .description('List all properties on a profile')
     .action((options) => {});
 
 program.parse(process.argv);

--- a/src/commands/property/common-cli.ts
+++ b/src/commands/property/common-cli.ts
@@ -1,0 +1,46 @@
+import chalk from 'chalk';
+import inquirer from 'inquirer';
+
+import * as messages from './common-text';
+
+export const promptKey = async (): Promise<string> => {
+    const { propname } = await inquirer.prompt([
+        {
+            type: 'input',
+            name: 'propname',
+            message: messages.ENTER_KEY,
+        },
+    ]);
+    if (!propname) {
+        console.log(chalk.red(messages.INVALID_KEY));
+    }
+    return propname;
+};
+
+export const promptValue = async (
+    key: string,
+    secret: boolean
+): Promise<string> => {
+    const secretPrompt = {
+        type: 'password',
+        name: 'value',
+        message: messages.ENTER_SECRET_VALUE,
+        mask: '*',
+    };
+
+    const publicPrompt = {
+        type: 'input',
+        name: 'value',
+        message: messages.ENTER_VALUE,
+    };
+
+    const prompt = secret ? secretPrompt : publicPrompt;
+
+    const { value } = await inquirer.prompt([prompt]);
+
+    if (!value) {
+        console.log(chalk.red(messages.INVALID_VALUE));
+    }
+
+    return value;
+};

--- a/src/commands/property/common-cli.ts
+++ b/src/commands/property/common-cli.ts
@@ -19,12 +19,13 @@ export const promptKey = async (): Promise<string> => {
 
 export const promptValue = async (
     key: string,
-    secret: boolean
+    secret: boolean,
+    masked: boolean
 ): Promise<string> => {
     const secretPrompt = {
         type: 'password',
         name: 'value',
-        message: messages.ENTER_SECRET_VALUE,
+        message: messages.ENTER_HIDDEN_VALUE,
         mask: '*',
     };
 
@@ -34,7 +35,7 @@ export const promptValue = async (
         message: messages.ENTER_VALUE,
     };
 
-    const prompt = secret ? secretPrompt : publicPrompt;
+    const prompt = secret || masked ? secretPrompt : publicPrompt;
 
     const { value } = await inquirer.prompt([prompt]);
 

--- a/src/commands/property/common-text.ts
+++ b/src/commands/property/common-text.ts
@@ -1,0 +1,5 @@
+export const ENTER_KEY = 'Enter key: ';
+export const INVALID_KEY = 'Invalid key, try again';
+export const ENTER_SECRET_VALUE = 'Enter secret value: ';
+export const ENTER_VALUE = 'Enter value: ';
+export const INVALID_VALUE = 'Invalid value, try again';

--- a/src/commands/property/common-text.ts
+++ b/src/commands/property/common-text.ts
@@ -1,5 +1,5 @@
 export const ENTER_KEY = 'Enter key:';
 export const INVALID_KEY = 'Invalid key, try again';
-export const ENTER_SECRET_VALUE = 'Enter secret value:';
+export const ENTER_HIDDEN_VALUE = 'Enter hidden value:';
 export const ENTER_VALUE = 'Enter value:';
 export const INVALID_VALUE = 'Invalid value, try again';

--- a/src/commands/property/common-text.ts
+++ b/src/commands/property/common-text.ts
@@ -1,5 +1,5 @@
-export const ENTER_KEY = 'Enter key: ';
+export const ENTER_KEY = 'Enter key:';
 export const INVALID_KEY = 'Invalid key, try again';
-export const ENTER_SECRET_VALUE = 'Enter secret value: ';
-export const ENTER_VALUE = 'Enter value: ';
+export const ENTER_SECRET_VALUE = 'Enter secret value:';
+export const ENTER_VALUE = 'Enter value:';
 export const INVALID_VALUE = 'Invalid value, try again';

--- a/src/commands/property/get-cli.ts
+++ b/src/commands/property/get-cli.ts
@@ -22,5 +22,6 @@ export const handleGet = async (
         console.log(value);
     } else {
         console.log(chalk.red(messages.NOT_FOUND), key);
+        process.exit(1);
     }
 };

--- a/src/commands/property/get-cli.ts
+++ b/src/commands/property/get-cli.ts
@@ -1,0 +1,26 @@
+import chalk from 'chalk';
+import * as common from '../../common';
+import * as propertyCommon from './common-cli';
+import * as messages from './get-text';
+import { getPropertyValue } from './get-utils';
+
+export const handleGet = async (
+    keyArg: string,
+    options: { global: boolean; profile: string; decode: boolean }
+): Promise<void> => {
+    common.assertGpmInitialized();
+
+    const { global, profile, decode } = options;
+
+    let key = keyArg;
+    while (!key) {
+        key = await propertyCommon.promptKey();
+    }
+
+    const value = getPropertyValue(key, global, profile, decode);
+    if (value) {
+        console.log(value);
+    } else {
+        console.log(chalk.red(messages.NOT_FOUND), key);
+    }
+};

--- a/src/commands/property/get-cli.ts
+++ b/src/commands/property/get-cli.ts
@@ -6,18 +6,23 @@ import { getPropertyValue } from './get-utils';
 
 export const handleGet = async (
     keyArg: string,
-    options: { global: boolean; profile: string; decode: boolean }
+    options: {
+        global: boolean;
+        profile: string;
+        decode: boolean;
+        unmask: boolean;
+    }
 ): Promise<void> => {
     common.assertGpmInitialized();
 
-    const { global, profile, decode } = options;
+    const { global, profile, decode, unmask } = options;
 
     let key = keyArg;
     while (!key) {
         key = await propertyCommon.promptKey();
     }
 
-    const value = getPropertyValue(key, global, profile, decode);
+    const value = getPropertyValue(key, global, profile, decode, unmask);
     if (value) {
         console.log(value);
     } else {

--- a/src/commands/property/get-text.ts
+++ b/src/commands/property/get-text.ts
@@ -1,0 +1,1 @@
+export const NOT_FOUND = "Property '%s' was not found";

--- a/src/commands/property/get-utils.ts
+++ b/src/commands/property/get-utils.ts
@@ -1,0 +1,37 @@
+import {
+    PropertiesFile,
+    Property,
+    PropertyType,
+} from '../../properties/properties-types';
+import * as common from '../../common';
+import * as constants from '../../constants';
+
+export const getPropertyValue = (
+    key: string,
+    global: boolean,
+    profile: string,
+    decode: boolean
+): string | undefined => {
+    // TODO: Support global properties
+
+    const property: Property | undefined = new PropertiesFile(
+        global
+            ? common.getProfilePropertiesPath(constants.GPM_GLOBAL_PROFILE_NAME)
+            : common.getProfilePropertiesPath(profile)
+    )
+        .load()
+        .getProperty(key);
+
+    if (!property) {
+        return undefined;
+    }
+
+    switch (property.type) {
+        case PropertyType.default:
+            return property.value;
+        case PropertyType.secret:
+            return decode
+                ? Buffer.from(property.value, 'base64').toString()
+                : property.value;
+    }
+};

--- a/src/commands/property/get-utils.ts
+++ b/src/commands/property/get-utils.ts
@@ -5,6 +5,7 @@ import {
 } from '../../properties/properties-types';
 import * as common from '../../common';
 import * as constants from '../../constants';
+import chalk from 'chalk';
 
 export const getPropertyValue = (
     key: string,
@@ -30,8 +31,8 @@ export const getPropertyValue = (
         case PropertyType.default:
             return property.value;
         case PropertyType.secret:
-            return decode
-                ? Buffer.from(property.value, 'base64').toString()
-                : property.value;
+            // No actual decoding has to happen since property values aren't
+            // encoded while in the Property object
+            return decode ? property.value : chalk.gray('(secret)');
     }
 };

--- a/src/commands/property/get-utils.ts
+++ b/src/commands/property/get-utils.ts
@@ -11,10 +11,9 @@ export const getPropertyValue = (
     key: string,
     global: boolean,
     profile: string,
-    decode: boolean
+    decode: boolean,
+    unmask: boolean
 ): string | undefined => {
-    // TODO: Support global properties
-
     const property: Property | undefined = new PropertiesFile(
         global
             ? common.getProfilePropertiesPath(constants.GPM_GLOBAL_PROFILE_NAME)
@@ -34,5 +33,15 @@ export const getPropertyValue = (
             // No actual decoding has to happen since property values aren't
             // encoded while in the Property object
             return decode ? property.value : chalk.gray('(secret)');
+        case PropertyType.masked:
+            return unmask
+                ? property.value
+                : `${property.value.replace(/./g, '*')} ${chalk.gray(
+                      '(masked)'
+                  )}`;
+        default:
+            throw Error(
+                `Can't display unknown property type: ${property.type}`
+            );
     }
 };

--- a/src/commands/property/ls-cli.ts
+++ b/src/commands/property/ls-cli.ts
@@ -1,0 +1,19 @@
+import chalk from 'chalk';
+import { listProperties } from './ls-utils';
+import * as common from '../../common';
+
+export const handleLs = async (options: {
+    global: boolean;
+    profile: string;
+}): Promise<void> => {
+    common.assertGpmInitialized();
+
+    const { global, profile } = options;
+
+    try {
+        listProperties(profile, global);
+    } catch (ERROR) {
+        console.log(chalk.red(ERROR));
+        process.exit(1);
+    }
+};

--- a/src/commands/property/ls-utils.ts
+++ b/src/commands/property/ls-utils.ts
@@ -1,0 +1,73 @@
+import table from 'text-table';
+import chalk from 'chalk';
+import stripAnsi from 'strip-ansi';
+
+import * as common from '../../common';
+import * as constants from '../../constants';
+import {
+    PropertiesFile,
+    PropertyType,
+} from '../../properties/properties-types';
+
+export const listProperties = (profile: string, global: boolean): void => {
+    const globalProperties = new PropertiesFile(
+        constants.GPM_GLOBAL_PROPERTIES_FILE_LOCATION
+    ).load();
+    const profileProperties: PropertiesFile = new PropertiesFile(
+        common.getProfilePropertiesPath(profile)
+    ).load();
+
+    let globalPropertyWasOverridden = false;
+
+    const getPropertiesTable = (
+        file: PropertiesFile,
+        isGlobal = false
+    ): string[][] => {
+        const propertiesList: string[][] = [
+            [chalk.green('Key'), chalk.green('Value')],
+        ];
+
+        file.getProperties().forEach((prop) => {
+            const overriddenByProfile = isGlobal
+                ? false
+                : globalProperties.getProperty(prop.key) != undefined;
+            globalPropertyWasOverridden =
+                globalPropertyWasOverridden || overriddenByProfile;
+
+            const key = overriddenByProfile
+                ? `${prop.key} ${chalk.blueBright('(*)')}`
+                : prop.key;
+            const value =
+                prop.type == PropertyType.secret
+                    ? `${Buffer.from(prop.value).toString(
+                          'base64'
+                      )} ${chalk.gray('(secret)')}`
+                    : prop.value;
+            propertiesList.push([key, value]);
+        });
+
+        return propertiesList;
+    };
+
+    if (global) {
+        console.log(chalk.green('[global]'));
+        console.log(
+            table(getPropertiesTable(globalProperties, true), {
+                stringLength: (s) => stripAnsi(s).length,
+            })
+        );
+        console.log();
+    }
+
+    console.log(chalk.green(`[${profile}]`));
+    console.log(
+        table(getPropertiesTable(profileProperties), {
+            stringLength: (s) => stripAnsi(s).length,
+        })
+    );
+
+    if (globalPropertyWasOverridden) {
+        console.log();
+        console.log(chalk.blueBright('*'), '=', 'overriding global property');
+    }
+};

--- a/src/commands/property/ls-utils.ts
+++ b/src/commands/property/ls-utils.ts
@@ -49,18 +49,12 @@ export const listProperties = (profile: string, global: boolean): void => {
                     break;
                 case PropertyType.default:
                     value = prop.value;
-                    for (const str of constants.SENSITIVE_KEY_PATTERNS) {
-                        if (
-                            prop.key.toLowerCase().includes(str.toLowerCase())
-                        ) {
-                            value = `${prop.value.replace(
-                                /./g,
-                                '*'
-                            )} ${chalk.gray('(masked)')}`;
-                            propertyWasMasked = true;
-                            break;
-                        }
-                    }
+                    break;
+                case PropertyType.masked:
+                    value = `${prop.value.replace(/./g, '*')} ${chalk.gray(
+                        '(masked)'
+                    )}`;
+                    propertyWasMasked = true;
                     break;
                 default:
                     throw Error(
@@ -97,17 +91,13 @@ export const listProperties = (profile: string, global: boolean): void => {
     if (propertyWasMasked) {
         legend.push([
             chalk.blueBright('masked'),
-            `${chalk.cyan(
-                'key'
-            )} name contained one of the following patterns: ${chalk.cyanBright(
-                constants.SENSITIVE_KEY_PATTERNS.join(' ')
-            )}`,
+            `property was set with ${chalk.cyanBright('--masked')} flag`,
         ]);
     }
     if (secretWasMasked) {
         legend.push([
             chalk.blueBright('secret'),
-            `property was set with ${chalk.cyanBright('--encode')} flag`,
+            `property was set with ${chalk.cyanBright('--encoded')} flag`,
         ]);
     }
 

--- a/src/commands/property/set-cli.ts
+++ b/src/commands/property/set-cli.ts
@@ -7,13 +7,26 @@ import * as propertyCommon from './common-cli';
 export const handleSet = async (
     keyArg: string,
     valueArg: string,
-    options: { encode: boolean; global: boolean; profile: string }
+    options: {
+        encoded: boolean;
+        masked: boolean;
+        global: boolean;
+        profile: string;
+    }
 ): Promise<void> => {
     common.assertGpmInitialized();
 
-    const { encode, global, profile } = options;
+    const { encoded, masked, global, profile } = options;
+
+    // Default value of profile is the current one. Because of that, we can't
+    // explicitly detect whether the user set the profile or not. This is a guess
     if (global && profile != common.getCurrentProfileName()) {
         console.log(chalk.red(messages.INVALID_OPTIONS));
+        process.exit(1);
+    }
+
+    if (encoded && masked) {
+        console.log(chalk.red(messages.INVALID_TYPE));
         process.exit(1);
     }
 
@@ -23,11 +36,11 @@ export const handleSet = async (
         key = await propertyCommon.promptKey();
     }
     while (!value) {
-        value = await propertyCommon.promptValue(key, encode);
+        value = await propertyCommon.promptValue(key, encoded, masked);
     }
 
     try {
-        await setProperty(key, value, encode, global, profile);
+        await setProperty(key, value, encoded, masked, global, profile);
         console.log(
             chalk.green(messages.SUCCESSFUL_PROP_ADDED),
             key,

--- a/src/commands/property/set-cli.ts
+++ b/src/commands/property/set-cli.ts
@@ -26,7 +26,6 @@ export const handleSet = async (
         console.log(chalk.green(messages.SUCCESSFUL_PROP_ADDED), key, profile);
     } catch (ERROR) {
         console.log(chalk.red(ERROR));
+        process.exit(1);
     }
-
-    // TODO: Still need to "recompile" ~/.gradle/gradle.properties after set
 };

--- a/src/commands/property/set-cli.ts
+++ b/src/commands/property/set-cli.ts
@@ -1,75 +1,32 @@
 import chalk from 'chalk';
-import inquirer from 'inquirer';
-import { addProperty } from './set-utils';
-import {
-    ENTER_KEY,
-    INVALID_KEY,
-    ENTER_VALUE,
-    ENTER_SECRET_VALUE,
-    INVALID_VALUE,
-    ADDING_PROP,
-    SUCCESSFUL_PROP_ADDED,
-} from './set-text';
-
-const promptKey = async () => {
-    const { propname } = await inquirer.prompt([
-        {
-            type: 'input',
-            name: 'propname',
-            message: ENTER_KEY,
-        },
-    ]);
-    if (!propname) {
-        console.log(chalk.red(INVALID_KEY));
-    }
-    return propname;
-};
-
-const promptValue = async (key: string, secret: boolean) => {
-    const secretPrompt = {
-        type: 'password',
-        name: 'value',
-        message: ENTER_SECRET_VALUE,
-        mask: '*',
-    };
-
-    const publicPrompt = {
-        type: 'input',
-        name: 'value',
-        message: ENTER_VALUE,
-    };
-
-    const prompt = secret ? secretPrompt : publicPrompt;
-
-    const { value } = await inquirer.prompt([prompt]);
-
-    if (!value) {
-        console.log(chalk.red(INVALID_VALUE));
-    }
-
-    return value;
-};
+import { setProperty } from './set-utils';
+import * as messages from './set-text';
+import * as common from '../../common';
+import * as propertyCommon from './common-cli';
 
 export const handleSet = async (
     keyArg: string,
     valueArg: string,
-    options: { secret: boolean; global: boolean }
+    options: { secret: boolean; global: boolean; profile: string }
 ): Promise<void> => {
-    const { secret, global } = options;
+    common.assertGpmInitialized();
+
+    const { secret, global, profile } = options;
     let key = keyArg;
     let value = valueArg;
     while (!key) {
-        key = await promptKey();
+        key = await propertyCommon.promptKey();
     }
     while (!value) {
-        value = await promptValue(key, secret);
+        value = await propertyCommon.promptValue(key, secret);
     }
 
-    console.log(chalk.yellow(ADDING_PROP), `${key}=${value}`);
     try {
-        await addProperty(key, value, secret, global);
-        console.log(chalk.green(SUCCESSFUL_PROP_ADDED));
+        await setProperty(key, value, secret, global, profile);
+        console.log(chalk.green(messages.SUCCESSFUL_PROP_ADDED), key, profile);
     } catch (ERROR) {
         console.log(chalk.red(ERROR));
     }
+
+    // TODO: Still need to "recompile" ~/.gradle/gradle.properties after set
 };

--- a/src/commands/property/set-cli.ts
+++ b/src/commands/property/set-cli.ts
@@ -7,23 +7,32 @@ import * as propertyCommon from './common-cli';
 export const handleSet = async (
     keyArg: string,
     valueArg: string,
-    options: { secret: boolean; global: boolean; profile: string }
+    options: { encode: boolean; global: boolean; profile: string }
 ): Promise<void> => {
     common.assertGpmInitialized();
 
-    const { secret, global, profile } = options;
+    const { encode, global, profile } = options;
+    if (global && profile != common.getCurrentProfileName()) {
+        console.log(chalk.red(messages.INVALID_OPTIONS));
+        process.exit(1);
+    }
+
     let key = keyArg;
     let value = valueArg;
     while (!key) {
         key = await propertyCommon.promptKey();
     }
     while (!value) {
-        value = await propertyCommon.promptValue(key, secret);
+        value = await propertyCommon.promptValue(key, encode);
     }
 
     try {
-        await setProperty(key, value, secret, global, profile);
-        console.log(chalk.green(messages.SUCCESSFUL_PROP_ADDED), key, profile);
+        await setProperty(key, value, encode, global, profile);
+        console.log(
+            chalk.green(messages.SUCCESSFUL_PROP_ADDED),
+            key,
+            global ? 'global' : profile
+        );
     } catch (ERROR) {
         console.log(chalk.red(ERROR));
         process.exit(1);

--- a/src/commands/property/set-text.ts
+++ b/src/commands/property/set-text.ts
@@ -1,7 +1,2 @@
-export const ENTER_KEY = 'Enter key: ';
-export const INVALID_KEY = 'Invalid key, try again';
-export const ENTER_VALUE = 'Enter value: ';
-export const ENTER_SECRET_VALUE = 'Enter secret value: ';
-export const INVALID_VALUE = 'Invalid value, try again';
-export const ADDING_PROP = 'Adding property: ';
-export const SUCCESSFUL_PROP_ADDED = 'Successfully added property';
+export const SUCCESSFUL_PROP_ADDED =
+    "Successfully set property '%s' on profile: %s";

--- a/src/commands/property/set-text.ts
+++ b/src/commands/property/set-text.ts
@@ -1,2 +1,4 @@
 export const SUCCESSFUL_PROP_ADDED =
-    "Successfully set property '%s' on profile: %s";
+    "Successfully set property '%s' on scope: %s";
+export const INVALID_OPTIONS =
+    "Can't set on global and a profile at the same time";

--- a/src/commands/property/set-text.ts
+++ b/src/commands/property/set-text.ts
@@ -2,3 +2,4 @@ export const SUCCESSFUL_PROP_ADDED =
     "Successfully set property '%s' on scope: %s";
 export const INVALID_OPTIONS =
     "Can't set on global and a profile at the same time";
+export const INVALID_TYPE = "Can't use multiple types for a single property";

--- a/src/commands/property/set-utils.ts
+++ b/src/commands/property/set-utils.ts
@@ -8,7 +8,7 @@ import * as constants from '../../constants';
 export const setProperty = (
     key: string,
     value: string,
-    secret: boolean,
+    encode: boolean,
     global: boolean,
     profile: string
 ): boolean => {
@@ -24,7 +24,7 @@ export const setProperty = (
             key,
             value,
             // TODO: Consider allowing them to pass in a type string and casting to enum
-            secret ? PropertyType.secret : PropertyType.default
+            encode ? PropertyType.secret : PropertyType.default
         )
         .save();
 

--- a/src/commands/property/set-utils.ts
+++ b/src/commands/property/set-utils.ts
@@ -28,5 +28,9 @@ export const setProperty = (
         )
         .save();
 
+    if (profile == common.getCurrentProfileName()) {
+        common.compileGradleProperties(profile);
+    }
+
     return true;
 };

--- a/src/commands/property/set-utils.ts
+++ b/src/commands/property/set-utils.ts
@@ -1,10 +1,32 @@
-// TODO: implement logic for adding the property to the file
-export const addProperty = (
+import {
+    PropertiesFile,
+    PropertyType,
+} from '../../properties/properties-types';
+import * as common from '../../common';
+import * as constants from '../../constants';
+
+export const setProperty = (
     key: string,
     value: string,
     secret: boolean,
-    global: boolean
-) => {
-    // throw Error('OOPSIE!!!!');
+    global: boolean,
+    profile: string
+): boolean => {
+    // TODO: Support global properties
+
+    new PropertiesFile(
+        global
+            ? common.getProfilePropertiesPath(constants.GPM_GLOBAL_PROFILE_NAME)
+            : common.getProfilePropertiesPath(profile)
+    )
+        .load()
+        .setPropertyValue(
+            key,
+            value,
+            // TODO: Consider allowing them to pass in a type string and casting to enum
+            secret ? PropertyType.secret : PropertyType.default
+        )
+        .save();
+
     return true;
 };

--- a/src/commands/property/set-utils.ts
+++ b/src/commands/property/set-utils.ts
@@ -8,11 +8,17 @@ import * as constants from '../../constants';
 export const setProperty = (
     key: string,
     value: string,
-    encode: boolean,
+    encoded: boolean,
+    masked: boolean,
     global: boolean,
     profile: string
 ): boolean => {
-    // TODO: Support global properties
+    let type: PropertyType = PropertyType.default;
+    if (encoded) {
+        type = PropertyType.secret;
+    } else if (masked) {
+        type = PropertyType.masked;
+    }
 
     new PropertiesFile(
         global
@@ -24,7 +30,7 @@ export const setProperty = (
             key,
             value,
             // TODO: Consider allowing them to pass in a type string and casting to enum
-            encode ? PropertyType.secret : PropertyType.default
+            type
         )
         .save();
 

--- a/src/commands/property/unset-cli.ts
+++ b/src/commands/property/unset-cli.ts
@@ -1,0 +1,36 @@
+import chalk from 'chalk';
+import { removeProperty } from './unset-utils';
+import * as messages from './unset-text';
+import * as common from '../../common';
+import * as propertyCommon from './common-cli';
+
+export const handleUnset = async (
+    keyArg: string,
+    options: { global: boolean; profile: string }
+): Promise<void> => {
+    common.assertGpmInitialized();
+
+    const { global, profile } = options;
+
+    if (global && profile != common.getCurrentProfileName()) {
+        console.log(chalk.red(messages.INVALID_OPTIONS));
+        process.exit(1);
+    }
+
+    let key = keyArg;
+    while (!key) {
+        key = await propertyCommon.promptKey();
+    }
+
+    try {
+        removeProperty(key, profile, global);
+        console.log(
+            chalk.green(messages.SUCCESSFUL_PROP_REMOVAL),
+            key,
+            profile
+        );
+    } catch (ERROR) {
+        console.log(chalk.red(ERROR));
+        process.exit(1);
+    }
+};

--- a/src/commands/property/unset-cli.ts
+++ b/src/commands/property/unset-cli.ts
@@ -11,7 +11,6 @@ export const handleUnset = async (
     common.assertGpmInitialized();
 
     const { global, profile } = options;
-
     if (global && profile != common.getCurrentProfileName()) {
         console.log(chalk.red(messages.INVALID_OPTIONS));
         process.exit(1);
@@ -27,7 +26,7 @@ export const handleUnset = async (
         console.log(
             chalk.green(messages.SUCCESSFUL_PROP_REMOVAL),
             key,
-            profile
+            global ? 'global' : profile
         );
     } catch (ERROR) {
         console.log(chalk.red(ERROR));

--- a/src/commands/property/unset-text.ts
+++ b/src/commands/property/unset-text.ts
@@ -1,0 +1,4 @@
+export const SUCCESSFUL_PROP_REMOVAL =
+    "Successfully remove property '%s' on properties scope: %s";
+export const INVALID_OPTIONS =
+    "Can't remove on global and a profile at the same time";

--- a/src/commands/property/unset-text.ts
+++ b/src/commands/property/unset-text.ts
@@ -1,4 +1,4 @@
 export const SUCCESSFUL_PROP_REMOVAL =
-    "Successfully remove property '%s' on properties scope: %s";
+    "Successfully removed property '%s' on scope: %s";
 export const INVALID_OPTIONS =
     "Can't remove on global and a profile at the same time";

--- a/src/commands/property/unset-utils.ts
+++ b/src/commands/property/unset-utils.ts
@@ -1,0 +1,21 @@
+import * as common from '../../common';
+import * as constants from '../../constants';
+import { PropertiesFile } from '../../properties/properties-types';
+
+export const removeProperty = (
+    key: string,
+    profile: string,
+    global: boolean
+): void => {
+    if (global) {
+        new PropertiesFile(constants.GPM_GLOBAL_PROPERTIES_FILE_LOCATION)
+            .load()
+            .removeProperty(key)
+            .save();
+    } else {
+        new PropertiesFile(common.getProfilePropertiesPath(profile))
+            .load()
+            .removeProperty(key)
+            .save();
+    }
+};

--- a/src/common.ts
+++ b/src/common.ts
@@ -137,9 +137,15 @@ export const listAllProfiles = (): void => {
 };
 
 const MUST_DEFINE = "Parameter '%s' must be defined";
-export const assertDefined = (value: string, name: string): void => {
+const CANT_BE_EMPTY = "Parameter '%s' cannot be empty";
+export const assertNotNullOrEmpty = (value: string, name: string): void => {
     if (!value) {
         console.log(chalk.red(MUST_DEFINE), name);
+        process.exit(1);
+    }
+
+    if (value.length == 0 || value.trim().length == 0) {
+        console.log(chalk.red(CANT_BE_EMPTY), name);
         process.exit(1);
     }
 };

--- a/src/common.ts
+++ b/src/common.ts
@@ -1,7 +1,19 @@
 import fs from 'fs';
 import { Dirent } from 'node:fs';
 import path from 'path';
+
+import chalk from 'chalk';
+
 import * as constants from './constants';
+
+const PROFILE_SWITCHED = 'Profile switched to: %s';
+const PROFILE_SWITCH_FAILED =
+    "Can't switch to profile '%s' as it doesn't exist";
+const PROFILE_ALREADY_EXISTS = "Profile '%s' already exists";
+const PROFILE_DOESNT_EXIST = "Profile '%s' does not exist";
+const CANT_DELETE_CURRENT_PROFILE =
+    "Can't delete profile '%s' as that's the current profile";
+const PROFILE_DELETED = 'Sucessfully deleted profile: %s';
 
 export const log = (message: string, level: number): void => {
     console.log(message, level);
@@ -11,6 +23,13 @@ export const getCurrentProfileName = (): string => {
     return fs.readFileSync(constants.GPM_CURRENT_PROFILE_FILE_LOCATION, {
         encoding: 'utf-8',
     });
+};
+
+export const getProfileFileLocation = (profile: string): string => {
+    return path.join(
+        constants.GPM_HOME_DIRECTORY_LOCATION,
+        `${profile}.${constants.PROPERTIES_FILE_EXTENSION}`
+    );
 };
 
 export const profileExists = (profile: string): boolean => {
@@ -40,9 +59,8 @@ export const createGlobalProfile = (): void => {
 
 export const createProfile = (profile: string): void => {
     if (profileExists(profile)) {
-        throw new Error(
-            `Can't create profile '${profile}' as it already exists`
-        );
+        console.log(chalk.red(PROFILE_ALREADY_EXISTS), profile);
+        process.exit(1);
     } else {
         fs.writeFileSync(
             path.join(
@@ -55,19 +73,38 @@ export const createProfile = (profile: string): void => {
     }
 };
 
-export const setProfile = (profile: string): void => {
+export const deleteProfile = (profile: string, alert = false): boolean => {
+    if (!profileExists(profile)) {
+        console.log(chalk.red(PROFILE_DOESNT_EXIST), profile);
+        process.exit(1);
+    }
+
+    if (getCurrentProfileName() == profile) {
+        console.log(chalk.red(CANT_DELETE_CURRENT_PROFILE), profile);
+        process.exit(1);
+    }
+
+    fs.unlinkSync(getProfileFileLocation(profile));
+    console.log(chalk.green(PROFILE_DELETED), profile);
+
+    return true;
+};
+
+export const setProfile = (profile: string, alert = false): void => {
     if (profileExists(profile)) {
         fs.writeFileSync(constants.GPM_CURRENT_PROFILE_FILE_LOCATION, profile);
         // TODO: Overwrite the content of gradle.properties with those
         // inside of this profile + global
+        if (alert) {
+            console.log(chalk.green(PROFILE_SWITCHED), profile);
+        }
     } else {
-        throw new Error(
-            `Can't switch to profile '${profile}' as it doesn't exist`
-        );
+        console.log(chalk.red(PROFILE_SWITCH_FAILED), profile);
+        process.exit(1);
     }
 };
 
-export const getAllProfiles = (): string[] => {
+export const getAllProfileNames = (): string[] => {
     const gpmHomeFiles: Dirent[] = fs.readdirSync(
         constants.GPM_HOME_DIRECTORY_LOCATION,
         {
@@ -82,9 +119,64 @@ export const getAllProfiles = (): string[] => {
                 dir.name != constants.GPM_GLOBAL_PROPERTIES_FILE_NAME
             );
         })
-        .map((dir: Dirent): string => path.basename(dir.name));
+        .map((dir: Dirent): string => path.parse(dir.name).name);
 
     return profiles;
+};
+
+export const listAllProfiles = (): void => {
+    const currentProfile = getCurrentProfileName();
+    const profiles = getAllProfileNames();
+    profiles.forEach((profile) => {
+        if (profile != currentProfile) {
+            console.log(chalk.blueBright(profile));
+        } else {
+            console.log(chalk.cyanBright.bold(profile));
+        }
+    });
+};
+
+const MUST_DEFINE = "Parameter '%s' must be defined";
+export const assertDefined = (value: string, name: string): void => {
+    if (!value) {
+        console.log(chalk.red(MUST_DEFINE), name);
+        process.exit(1);
+    }
+};
+
+export const gpmInitialized = (): boolean => {
+    // TODO: Account for incomplete initialization. For example,
+    // if the .gpm home directory has been created, that doesn't
+    // necessarily mean there's an active profile and respective
+    // gpm-controlled gradle.properties file
+
+    if (fs.existsSync(constants.GPM_HOME_DIRECTORY_LOCATION)) {
+        return true;
+    }
+
+    let gradlePropertiesFileContent: string;
+    if (fs.existsSync(constants.GRADLE_PROPERTIES_FILE_LOCATION)) {
+        gradlePropertiesFileContent = fs.readFileSync(
+            constants.GRADLE_PROPERTIES_FILE_LOCATION,
+            'utf-8'
+        );
+    } else {
+        return false;
+    }
+
+    if (gradlePropertiesFileContent.includes(constants.GPM_ANNOTATION)) {
+        return true;
+    }
+
+    return false;
+};
+
+const NOT_INITIALIZED = 'gpm not yet initialized';
+export const assertGpmInitialized = (): void => {
+    if (!gpmInitialized()) {
+        console.log(chalk.red(NOT_INITIALIZED));
+        process.exit(1);
+    }
 };
 
 export const writePropertyToProfile = (

--- a/src/common.ts
+++ b/src/common.ts
@@ -1,3 +1,92 @@
+import fs from 'fs';
+import { Dirent } from 'node:fs';
+import path from 'path';
+import * as constants from './constants';
+
 export const log = (message: string, level: number): void => {
     console.log(message, level);
 };
+
+export const getCurrentProfileName = (): string => {
+    return fs.readFileSync(constants.GPM_CURRENT_PROFILE_FILE_LOCATION, {
+        encoding: 'utf-8',
+    });
+};
+
+export const profileExists = (profile: string): boolean => {
+    if (profile == constants.GPM_GLOBAL_PROPERTIES_PROFILE) {
+        throw new Error(
+            `'${profile}' is not a valid profile, it's the global properties store`
+        );
+    }
+
+    const profileLocation: string = path.join(
+        constants.GPM_HOME_DIRECTORY_LOCATION,
+        `${profile}.${constants.PROPERTIES_FILE_EXTENSION}`
+    );
+
+    return fs.existsSync(profileLocation);
+};
+
+export const createGlobalProfile = (): void => {
+    if (!fs.existsSync(constants.GPM_GLOBAL_PROPERTIES_FILE_LOCATION)) {
+        fs.writeFileSync(
+            constants.GPM_GLOBAL_PROPERTIES_FILE_LOCATION,
+            constants.GPM_ANNOTATION,
+            { encoding: 'utf-8' }
+        );
+    }
+};
+
+export const createProfile = (profile: string): void => {
+    if (profileExists(profile)) {
+        throw new Error(
+            `Can't create profile '${profile}' as it already exists`
+        );
+    } else {
+        fs.writeFileSync(
+            path.join(
+                constants.GPM_HOME_DIRECTORY_LOCATION,
+                `${profile}.${constants.PROPERTIES_FILE_EXTENSION}`
+            ),
+            constants.GPM_ANNOTATION,
+            { encoding: 'utf-8' }
+        );
+    }
+};
+
+export const setProfile = (profile: string): void => {
+    if (profileExists(profile)) {
+        fs.writeFileSync(constants.GPM_CURRENT_PROFILE_FILE_LOCATION, profile);
+    } else {
+        throw new Error(
+            `Can't switch to profile '${profile}' as it doesn't exist`
+        );
+    }
+};
+
+export const getAllProfiles = (): string[] => {
+    const gpmHomeFiles: Dirent[] = fs.readdirSync(
+        constants.GPM_HOME_DIRECTORY_LOCATION,
+        {
+            withFileTypes: true,
+        }
+    );
+    const profiles: string[] = gpmHomeFiles
+        .filter((dir: Dirent): boolean => {
+            return (
+                path.extname(dir.name) ==
+                    `.${constants.PROPERTIES_FILE_EXTENSION}` &&
+                dir.name != constants.GPM_GLOBAL_PROPERTIES_FILE_NAME
+            );
+        })
+        .map((dir: Dirent): string => path.basename(dir.name));
+
+    return profiles;
+};
+
+export const writePropertyToProfile = (
+    profile: string,
+    key: string,
+    value: string
+): void => {};

--- a/src/common.ts
+++ b/src/common.ts
@@ -1,10 +1,11 @@
 import fs from 'fs';
-import { Dirent } from 'node:fs';
+import { Dirent, PathLike } from 'node:fs';
 import path from 'path';
 
 import chalk from 'chalk';
 
 import * as constants from './constants';
+import { PropertyType } from './properties/properties-types';
 
 const PROFILE_SWITCHED = 'Profile switched to: %s';
 const PROFILE_SWITCH_FAILED =
@@ -27,20 +28,20 @@ export const getCurrentProfileName = (): string => {
 
 export const getProfileFileLocation = (profile: string): string => {
     return path.join(
-        constants.GPM_HOME_DIRECTORY_LOCATION,
+        constants.GPM_HOME_PATH,
         `${profile}.${constants.PROPERTIES_FILE_EXTENSION}`
     );
 };
 
 export const profileExists = (profile: string): boolean => {
-    if (profile == constants.GPM_GLOBAL_PROPERTIES_PROFILE) {
+    if (profile == constants.GPM_GLOBAL_PROFILE_NAME) {
         throw new Error(
             `'${profile}' is not a valid profile, it's the global properties store`
         );
     }
 
     const profileLocation: string = path.join(
-        constants.GPM_HOME_DIRECTORY_LOCATION,
+        constants.GPM_HOME_PATH,
         `${profile}.${constants.PROPERTIES_FILE_EXTENSION}`
     );
 
@@ -64,7 +65,7 @@ export const createProfile = (profile: string): void => {
     } else {
         fs.writeFileSync(
             path.join(
-                constants.GPM_HOME_DIRECTORY_LOCATION,
+                constants.GPM_HOME_PATH,
                 `${profile}.${constants.PROPERTIES_FILE_EXTENSION}`
             ),
             constants.GPM_ANNOTATION,
@@ -105,12 +106,9 @@ export const setProfile = (profile: string, alert = false): void => {
 };
 
 export const getAllProfileNames = (): string[] => {
-    const gpmHomeFiles: Dirent[] = fs.readdirSync(
-        constants.GPM_HOME_DIRECTORY_LOCATION,
-        {
-            withFileTypes: true,
-        }
-    );
+    const gpmHomeFiles: Dirent[] = fs.readdirSync(constants.GPM_HOME_PATH, {
+        withFileTypes: true,
+    });
     const profiles: string[] = gpmHomeFiles
         .filter((dir: Dirent): boolean => {
             return (
@@ -156,7 +154,7 @@ export const gpmInitialized = (): boolean => {
     // necessarily mean there's an active profile and respective
     // gpm-controlled gradle.properties file
 
-    if (fs.existsSync(constants.GPM_HOME_DIRECTORY_LOCATION)) {
+    if (fs.existsSync(constants.GPM_HOME_PATH)) {
         return true;
     }
 
@@ -185,8 +183,32 @@ export const assertGpmInitialized = (): void => {
     }
 };
 
-export const writePropertyToProfile = (
-    profile: string,
-    key: string,
-    value: string
-): void => {};
+export const getCurrentProfilePropertiesPath = (): PathLike => {
+    return path.join(
+        constants.GPM_HOME_PATH,
+        `${getCurrentProfileName()}.${constants.PROPERTIES_FILE_EXTENSION}`
+    );
+};
+
+export const getProfilePropertiesPath = (profile: string): PathLike => {
+    return path.join(
+        constants.GPM_HOME_PATH,
+        `${profile}.${constants.PROPERTIES_FILE_EXTENSION}`
+    );
+};
+
+export const getPropertyTypeAnnotation = (type: PropertyType): string => {
+    return (
+        constants.GPM_TYPE_ANNOTATION +
+        constants.PROPERTIES_SEPARATOR +
+        type.toString()
+    );
+};
+
+export const getAnnotationPropertyType = (annotation: string): PropertyType => {
+    return PropertyType[
+        annotation.split(
+            constants.PROPERTIES_SEPARATOR
+        )[1] as keyof typeof PropertyType
+    ];
+};

--- a/src/common.ts
+++ b/src/common.ts
@@ -116,7 +116,7 @@ export const compileGradleProperties = (profile: string): void => {
 
     new PropertiesFile(
         constants.GRADLE_PROPERTIES_FILE_LOCATION,
-        PropertiesFormat.gradle
+        PropertiesFormat.gpm
     )
         .load()
         .setProperties(global)

--- a/src/common.ts
+++ b/src/common.ts
@@ -58,6 +58,8 @@ export const createProfile = (profile: string): void => {
 export const setProfile = (profile: string): void => {
     if (profileExists(profile)) {
         fs.writeFileSync(constants.GPM_CURRENT_PROFILE_FILE_LOCATION, profile);
+        // TODO: Overwrite the content of gradle.properties with those
+        // inside of this profile + global
     } else {
         throw new Error(
             `Can't switch to profile '${profile}' as it doesn't exist`

--- a/src/common.ts
+++ b/src/common.ts
@@ -60,13 +60,15 @@ export const createGlobalProfile = (): void => {
     if (!fs.existsSync(constants.GPM_GLOBAL_PROPERTIES_FILE_LOCATION)) {
         fs.writeFileSync(
             constants.GPM_GLOBAL_PROPERTIES_FILE_LOCATION,
-            constants.GPM_ANNOTATION,
+            `${constants.GPM_ANNOTATION}\n${constants.GPM_API_VERSION_ANNOTATION}`,
             { encoding: 'utf-8' }
         );
     }
 };
 
 export const createProfile = (profile: string, alert = false): void => {
+    // TODO: Add in file name validation
+
     if (profileExists(profile)) {
         console.log(chalk.red(PROFILE_ALREADY_EXISTS), profile);
         process.exit(1);
@@ -76,7 +78,7 @@ export const createProfile = (profile: string, alert = false): void => {
                 constants.GPM_HOME_PATH,
                 `${profile}.${constants.PROPERTIES_FILE_EXTENSION}`
             ),
-            constants.GPM_ANNOTATION,
+            `${constants.GPM_ANNOTATION}\n${constants.GPM_API_VERSION_ANNOTATION}`,
             { encoding: 'utf-8' }
         );
     }
@@ -108,20 +110,23 @@ export const compileGradleProperties = (profile: string): void => {
         getProfilePropertiesPath(profile)
     ).load();
 
+    const global = new PropertiesFile(
+        constants.GPM_GLOBAL_PROPERTIES_FILE_LOCATION
+    ).load();
+
     new PropertiesFile(
         constants.GRADLE_PROPERTIES_FILE_LOCATION,
         PropertiesFormat.gradle
     )
         .load()
-        .setProperties(profilePropertiesFile)
+        .setProperties(global)
+        .addProperties(profilePropertiesFile)
         .save();
 };
 
 export const setProfile = (profile: string, alert = false): void => {
     if (profileExists(profile)) {
         fs.writeFileSync(constants.GPM_CURRENT_PROFILE_FILE_LOCATION, profile);
-        // TODO: Overwrite the content of gradle.properties with those
-        // inside of this profile + global
     } else {
         console.log(chalk.red(PROFILE_SWITCH_FAILED), profile);
         process.exit(1);
@@ -154,11 +159,11 @@ export const getAllProfileNames = (): string[] => {
 export const listAllProfiles = (): void => {
     const currentProfile = getCurrentProfileName();
     const profiles = getAllProfileNames();
+
+    console.log(chalk.cyanBright.bold(currentProfile));
     profiles.forEach((profile) => {
         if (profile != currentProfile) {
             console.log(chalk.blueBright(profile));
-        } else {
-            console.log(chalk.cyanBright.bold(profile));
         }
     });
 };

--- a/src/constants.ts
+++ b/src/constants.ts
@@ -23,7 +23,18 @@ export const GPM_HOME_DIRECTORY_LOCATION = path.join(
     GPM_HOME_DIRECTORY_NAME
 );
 export const GPM_GLOBAL_PROPERTIES_FILE_NAME = 'global.properties';
+export const GPM_GLOBAL_PROPERTIES_FILE_LOCATION = path.join(
+    GPM_HOME_DIRECTORY_LOCATION,
+    GPM_GLOBAL_PROPERTIES_FILE_NAME
+);
+export const GPM_GLOBAL_PROPERTIES_PROFILE = 'global';
 export const GPM_DEFAULT_PROFILE_NAME = 'default';
-export const GPM_CURRENT_PROFILE_FILE_MARKER = '.currentprofile';
+export const GPM_CURRENT_PROFILE_FILE_NAME = 'profile';
+export const GPM_CURRENT_PROFILE_FILE_LOCATION = path.join(
+    GPM_HOME_DIRECTORY_LOCATION,
+    GPM_CURRENT_PROFILE_FILE_NAME
+);
 export const PROPERTIES_FILE_EXTENSION = 'properties';
-export const GPM_ANNOTATION = '//@gpm';
+// See to reference properties file allowed comments:
+// https://docs.oracle.com/javase/7/docs/api/java/util/Properties.html#load(java.io.Reader)
+export const GPM_ANNOTATION = '#@gpm';

--- a/src/constants.ts
+++ b/src/constants.ts
@@ -39,3 +39,5 @@ export const PROPERTIES_SEPARATOR = '=';
 export const GPM_ANNOTATION = '#@gpm';
 export const GPM_TYPE_ANNOTATION = '#@gpm-type';
 export const GPM_API_VERSION_ANNOTATION = '#@gpm-api=v0beta1';
+// TODO: Consider making this configurable to the user
+export const SENSITIVE_KEY_PATTERNS = ['auth', 'pass'];

--- a/src/constants.ts
+++ b/src/constants.ts
@@ -12,6 +12,11 @@ export const GRADLE_PROPERTIES_FILE_LOCATION = path.join(
     GRADLE_HOME_DIRECTORY_LOCATION,
     GRADLE_PROPERTIES_FILE_NAME
 );
+export const GRADLE_PROPERTIES_BAK_FILE_NAME = 'gradle.properties.bak';
+export const GRADLE_PROPERTIES_BAK_FILE_LOCATION = path.join(
+    GRADLE_HOME_DIRECTORY_LOCATION,
+    `${GRADLE_PROPERTIES_FILE_NAME}.bak`
+);
 export const GPM_HOME_DIRECTORY_NAME = '.gpm';
 export const GPM_HOME_DIRECTORY_LOCATION = path.join(
     USER_HOME,
@@ -21,3 +26,4 @@ export const GPM_GLOBAL_PROPERTIES_FILE_NAME = 'global.properties';
 export const GPM_DEFAULT_PROFILE_NAME = 'default';
 export const GPM_CURRENT_PROFILE_FILE_MARKER = '.currentprofile';
 export const PROPERTIES_FILE_EXTENSION = 'properties';
+export const GPM_ANNOTATION = '//@gpm';

--- a/src/constants.ts
+++ b/src/constants.ts
@@ -18,25 +18,22 @@ export const GRADLE_PROPERTIES_BAK_FILE_LOCATION = path.join(
     `${GRADLE_PROPERTIES_FILE_NAME}.bak`
 );
 export const GPM_HOME_DIRECTORY_NAME = '.gpm';
-export const GPM_HOME_DIRECTORY_LOCATION = path.join(
-    USER_HOME,
-    GPM_HOME_DIRECTORY_NAME
-);
+export const GPM_HOME_PATH = path.join(USER_HOME, GPM_HOME_DIRECTORY_NAME);
 export const GPM_GLOBAL_PROPERTIES_FILE_NAME = 'global.properties';
 export const GPM_GLOBAL_PROPERTIES_FILE_LOCATION = path.join(
-    GPM_HOME_DIRECTORY_LOCATION,
+    GPM_HOME_PATH,
     GPM_GLOBAL_PROPERTIES_FILE_NAME
 );
-export const GPM_GLOBAL_PROPERTIES_PROFILE = 'global';
+export const GPM_GLOBAL_PROFILE_NAME = 'global';
 export const GPM_DEFAULT_PROFILE_NAME = 'default';
 export const GPM_CURRENT_PROFILE_FILE_NAME = 'profile';
 export const GPM_CURRENT_PROFILE_FILE_LOCATION = path.join(
-    GPM_HOME_DIRECTORY_LOCATION,
+    GPM_HOME_PATH,
     GPM_CURRENT_PROFILE_FILE_NAME
 );
 export const PROPERTIES_FILE_EXTENSION = 'properties';
 export const PROPERTIES_COMMENT = '#';
-export const PROPERTIES_SPLITTER = '=';
+export const PROPERTIES_SEPARATOR = '=';
 // See to reference properties file allowed comments:
 // https://docs.oracle.com/javase/7/docs/api/java/util/Properties.html#load(java.io.Reader)
 export const GPM_ANNOTATION = '#@gpm';

--- a/src/constants.ts
+++ b/src/constants.ts
@@ -35,7 +35,9 @@ export const GPM_CURRENT_PROFILE_FILE_LOCATION = path.join(
     GPM_CURRENT_PROFILE_FILE_NAME
 );
 export const PROPERTIES_FILE_EXTENSION = 'properties';
-export const PROPERTIES_FILE_COMMENT_MARKER = '#';
+export const PROPERTIES_COMMENT = '#';
+export const PROPERTIES_SPLITTER = '=';
 // See to reference properties file allowed comments:
 // https://docs.oracle.com/javase/7/docs/api/java/util/Properties.html#load(java.io.Reader)
 export const GPM_ANNOTATION = '#@gpm';
+export const GPM_TYPE_ANNOTATION = '#@gpm-type';

--- a/src/constants.ts
+++ b/src/constants.ts
@@ -35,6 +35,7 @@ export const GPM_CURRENT_PROFILE_FILE_LOCATION = path.join(
     GPM_CURRENT_PROFILE_FILE_NAME
 );
 export const PROPERTIES_FILE_EXTENSION = 'properties';
+export const PROPERTIES_FILE_COMMENT_MARKER = '#';
 // See to reference properties file allowed comments:
 // https://docs.oracle.com/javase/7/docs/api/java/util/Properties.html#load(java.io.Reader)
 export const GPM_ANNOTATION = '#@gpm';

--- a/src/constants.ts
+++ b/src/constants.ts
@@ -38,3 +38,4 @@ export const PROPERTIES_SEPARATOR = '=';
 // https://docs.oracle.com/javase/7/docs/api/java/util/Properties.html#load(java.io.Reader)
 export const GPM_ANNOTATION = '#@gpm';
 export const GPM_TYPE_ANNOTATION = '#@gpm-type';
+export const GPM_API_VERSION_ANNOTATION = '#@gpm-api=v0beta1';

--- a/src/properties/properties-types-text.ts
+++ b/src/properties/properties-types-text.ts
@@ -1,0 +1,1 @@
+export const FILE_DOESNT_EXIST = "File '%s' does not exist";

--- a/src/properties/properties-types-utils.ts
+++ b/src/properties/properties-types-utils.ts
@@ -134,10 +134,6 @@ export const handleSave = (
                         `Can't save unknown property type: ${prop.type}`
                     );
             }
-        } else if (format == PropertiesFormat.gradle) {
-            lines.push(
-                prop.key + ` ${constants.PROPERTIES_SEPARATOR} ` + prop.value
-            );
         } else {
             throw Error("Can't save unrecognized properties file format");
         }

--- a/src/properties/properties-types-utils.ts
+++ b/src/properties/properties-types-utils.ts
@@ -86,6 +86,8 @@ export const handleLoad = (
             switch (type) {
                 case PropertyType.default:
                     break;
+                case PropertyType.masked:
+                    break;
                 case PropertyType.secret:
                     value = Buffer.from(value, 'base64').toString();
                     break;
@@ -116,9 +118,7 @@ export const handleSave = (
             switch (prop.type) {
                 case PropertyType.default:
                     lines.push(
-                        prop.key +
-                            ` ${constants.PROPERTIES_SEPARATOR} ` +
-                            prop.value
+                        `${prop.key} ${constants.PROPERTIES_SEPARATOR} ${prop.value}`
                     );
                     break;
                 case PropertyType.secret:
@@ -127,6 +127,12 @@ export const handleSave = (
                         prop.key +
                             ` ${constants.PROPERTIES_SEPARATOR} ` +
                             Buffer.from(prop.value).toString('base64')
+                    );
+                    break;
+                case PropertyType.masked:
+                    lines.push(common.getPropertyTypeAnnotation(prop.type));
+                    lines.push(
+                        `${prop.key} ${constants.PROPERTIES_SEPARATOR} ${prop.value}`
                     );
                     break;
                 default:

--- a/src/properties/properties-types-utils.ts
+++ b/src/properties/properties-types-utils.ts
@@ -107,7 +107,10 @@ export const handleSave = (
     path: PathLike,
     format: PropertiesFormat
 ): void => {
-    const lines: string[] = [constants.GPM_ANNOTATION];
+    const lines: string[] = [
+        constants.GPM_ANNOTATION,
+        constants.GPM_API_VERSION_ANNOTATION,
+    ];
     properties.forEach((prop) => {
         if (format == PropertiesFormat.gpm) {
             switch (prop.type) {

--- a/src/properties/properties-types.ts
+++ b/src/properties/properties-types.ts
@@ -115,6 +115,15 @@ export class PropertiesFile {
     }
 
     /**
+     * removeProperty
+     */
+    public removeProperty(key: string): PropertiesFile {
+        this.properties.delete(key);
+
+        return this;
+    }
+
+    /**
      * getPropertyValue
      */
     public getPropertyValue(key: string): string | undefined {

--- a/src/properties/properties-types.ts
+++ b/src/properties/properties-types.ts
@@ -7,6 +7,11 @@ export enum PropertyType {
     secret = 'secret',
 }
 
+export enum PropertiesFormat {
+    gpm = 'gpm',
+    gradle = 'gradle',
+}
+
 export class Property {
     public key: string;
     public value: string;
@@ -27,9 +32,14 @@ export class PropertiesFile {
     private path: fs.PathLike;
     private properties: Map<string, Property> = new Map();
     private loaded: boolean = false;
+    private format: PropertiesFormat;
 
-    constructor(path: fs.PathLike) {
+    constructor(
+        path: fs.PathLike,
+        format: PropertiesFormat = PropertiesFormat.gpm
+    ) {
         this.path = path;
+        this.format = format;
     }
 
     private assertLoaded() {
@@ -39,15 +49,16 @@ export class PropertiesFile {
         }
     }
 
-    load = (): PropertiesFile => {
+    public load = (): PropertiesFile => {
         this.properties = propertiesUtils.handleLoad(this.path);
         this.loaded = true;
         return this;
     };
 
-    save = (): PropertiesFile => {
+    public save = (): PropertiesFile => {
         this.assertLoaded();
-        propertiesUtils.handleSave(this.properties, this.path);
+
+        propertiesUtils.handleSave(this.properties, this.path, this.format);
         return this;
     };
 
@@ -61,12 +72,45 @@ export class PropertiesFile {
     }
 
     /**
+     * getProperties
+     */
+    public getProperties(): Map<string, Property> {
+        this.assertLoaded();
+
+        return this.properties;
+    }
+
+    /**
      * setProperty
      */
     public setProperty(key: string, property: Property): PropertiesFile {
         this.assertLoaded();
 
         this.properties.set(key, property);
+        return this;
+    }
+
+    /**
+     * addProperties
+     */
+    public addProperties(file: PropertiesFile): PropertiesFile {
+        this.assertLoaded();
+
+        file.getProperties().forEach((prop, key) => {
+            this.properties.set(key, prop);
+        });
+
+        return this;
+    }
+
+    /**
+     * addProperties
+     */
+    public setProperties(file: PropertiesFile): PropertiesFile {
+        this.assertLoaded();
+
+        this.properties = file.getProperties();
+
         return this;
     }
 

--- a/src/properties/properties-types.ts
+++ b/src/properties/properties-types.ts
@@ -1,0 +1,104 @@
+import * as fs from 'fs';
+
+import * as propertiesUtils from './properties-types-utils';
+
+export enum PropertyType {
+    default = 'default',
+    secret = 'secret',
+}
+
+export class Property {
+    public key: string;
+    public value: string;
+    public type: PropertyType;
+
+    constructor(
+        key: string,
+        value: string,
+        type: PropertyType = PropertyType.default
+    ) {
+        this.key = key;
+        this.value = value;
+        this.type = type;
+    }
+}
+
+export class PropertiesFile {
+    private path: fs.PathLike;
+    private properties: Map<string, Property> = new Map();
+    private loaded: boolean = false;
+
+    constructor(path: fs.PathLike) {
+        this.path = path;
+    }
+
+    private assertLoaded() {
+        if (!this.loaded) {
+            const message = `Properties file ${this.path} has not been loaded yet`;
+            throw Error(message);
+        }
+    }
+
+    load = (): PropertiesFile => {
+        this.properties = propertiesUtils.handleLoad(this.path);
+        this.loaded = true;
+        return this;
+    };
+
+    save = (): PropertiesFile => {
+        this.assertLoaded();
+        propertiesUtils.handleSave(this.properties, this.path);
+        return this;
+    };
+
+    /**
+     * getProperty
+     */
+    public getProperty(key: string): Property | undefined {
+        this.assertLoaded();
+
+        return this.properties.get(key);
+    }
+
+    /**
+     * setProperty
+     */
+    public setProperty(key: string, property: Property): PropertiesFile {
+        this.assertLoaded();
+
+        this.properties.set(key, property);
+        return this;
+    }
+
+    /**
+     * getPropertyValue
+     */
+    public getPropertyValue(key: string): string | undefined {
+        this.assertLoaded();
+
+        return this.properties.get(key)?.value;
+    }
+
+    /**
+     * setPropertyValue
+     */
+    public setPropertyValue(
+        key: string,
+        value: string,
+        type: PropertyType = PropertyType.default
+    ): PropertiesFile {
+        this.assertLoaded();
+
+        const prop = this.properties.get(key);
+        if (prop) {
+            prop.value = value;
+            prop.type = type;
+        } else {
+            // TODO: Consider sanitizing the key before it goes into the file
+            // so that people don't accidentally separate their key/value
+            this.properties.set(key, new Property(key, value, type));
+        }
+
+        return this;
+    }
+}

--- a/src/properties/properties-types.ts
+++ b/src/properties/properties-types.ts
@@ -5,6 +5,7 @@ import * as propertiesUtils from './properties-types-utils';
 export enum PropertyType {
     default = 'default',
     secret = 'secret',
+    masked = 'masked',
 }
 
 export enum PropertiesFormat {

--- a/src/properties/properties.ts
+++ b/src/properties/properties.ts
@@ -1,0 +1,65 @@
+import * as fs from 'fs';
+
+import chalk from 'chalk';
+
+const NOT_LOADED = "Properties file '%s' has not been loaded yet";
+const ALREADY_LOADED = "Properties file '%s' has already been loaded";
+const FILE_DOESNT_EXIST = "File '%s' does not exist";
+
+export type Properties = {
+    [key: string]: string;
+};
+
+export class PropertiesFile {
+    private path: fs.PathLike;
+    private properties: Properties = {};
+    private loaded: boolean = false;
+
+    constructor(path: fs.PathLike) {
+        this.path = path;
+    }
+
+    load = (force: boolean): void => {
+        if (this.loaded && !force) {
+            console.log(chalk.red(ALREADY_LOADED), this.path);
+            process.exit(1);
+        }
+
+        if (fs.existsSync(this.path)) {
+            console.log(chalk.red(FILE_DOESNT_EXIST), this.path);
+            process.exit(1);
+        }
+
+        // TODO: Implement .properties file deserializer
+    };
+
+    save = (): void => {
+        if (!this.loaded) {
+            console.log(chalk.red(NOT_LOADED), this.path);
+        }
+
+        // TODO: Implement .properties file serializer
+    };
+
+    /**
+     * getProperty
+     */
+    public getProperty(key: string): string {
+        if (!this.loaded) {
+            console.log(chalk.red(NOT_LOADED), this.path);
+        }
+
+        return this.properties[key];
+    }
+
+    /**
+     * setProperty
+     */
+    public setProperty(key: string, value: string): void {
+        if (!this.loaded) {
+            console.log(chalk.red(NOT_LOADED), this.path);
+        }
+
+        this.properties[key] = value;
+    }
+}

--- a/src/properties/properties.ts
+++ b/src/properties/properties.ts
@@ -2,35 +2,124 @@ import * as fs from 'fs';
 
 import chalk from 'chalk';
 
-const NOT_LOADED = "Properties file '%s' has not been loaded yet";
-const ALREADY_LOADED = "Properties file '%s' has already been loaded";
-const FILE_DOESNT_EXIST = "File '%s' does not exist";
+import * as constants from '../constants';
 
-export type Properties = {
-    [key: string]: string;
+const NOT_LOADED = "Properties file '%s' has not been loaded yet";
+const FILE_DOESNT_EXIST = "File '%s' does not exist";
+const PROPERTY_ALREADY_EXISTS =
+    "Property '%s' already exists, can't recreate it";
+
+export enum PropertyType {
+    default = 'default',
+    secret = 'secret',
+}
+
+export class Property {
+    public key: string;
+    public value: string;
+    public type: PropertyType;
+
+    constructor(
+        key: string,
+        value: string,
+        type: PropertyType = PropertyType.default
+    ) {
+        this.key = key;
+        this.value = value;
+        this.type = type;
+    }
+}
+
+const locations = (substring: string, str: string): number[] => {
+    const numbers: number[] = [];
+    let i: number = -1;
+    while ((i = str.indexOf(substring, i + 1)) >= 0) {
+        numbers.push(i);
+    }
+    return numbers;
+};
+
+// Aims to support the spec provided here (with annotations to support types):
+// https://docs.oracle.com/javase/7/docs/api/java/util/Properties.html#load(java.io.Reader)
+//
+// Currently only supports a very small subset of the spec
+const handleLoad = (propertiesPath: fs.PathLike): Map<string, Property> => {
+    if (!fs.existsSync(propertiesPath)) {
+        console.log(chalk.red(FILE_DOESNT_EXIST), propertiesPath);
+        process.exit(1);
+    }
+
+    const propertiesFileStr = fs
+        .readFileSync(propertiesPath, {
+            encoding: 'utf-8',
+        })
+        .trim();
+
+    const lines = propertiesFileStr.split(/[\r?\n]+/).map((line) => {
+        if (line.startsWith(constants.PROPERTIES_COMMENT)) {
+            return line;
+        }
+
+        const separatorLocations = locations(
+            constants.PROPERTIES_SPLITTER,
+            line
+        );
+        // Account for escaped separators
+        while (separatorLocations.length > 0) {
+            const prevChar: string | undefined =
+                line[separatorLocations[0] - 1];
+            if (!prevChar?.startsWith('\\')) {
+                const key = line.substring(0, separatorLocations[0]).trim();
+                const value = line
+                    .substring(separatorLocations[0] + 1, line.length)
+                    .trim();
+                return [key, value];
+            }
+
+            separatorLocations.shift();
+        }
+
+        // Key with no value
+        return [line, ''];
+    });
+
+    const properties: Map<string, Property> = new Map();
+    for (let i = 0; i < lines.length; ++i) {
+        if (Array.isArray(lines[i])) {
+            let type = PropertyType.default;
+
+            const previousLine = lines[i - 1];
+            // Previous line is a comment (non-arrays must be comments)
+            if (typeof previousLine === 'string') {
+                if (previousLine.startsWith(constants.GPM_TYPE_ANNOTATION)) {
+                    const typeString = previousLine.split('=')[1];
+                    type =
+                        PropertyType[typeString as keyof typeof PropertyType];
+                }
+            }
+
+            properties.set(
+                lines[i][0],
+                new Property(lines[i][0], lines[i][1], type)
+            );
+        }
+    }
+
+    return properties;
 };
 
 export class PropertiesFile {
     private path: fs.PathLike;
-    private properties: Properties = {};
+    private properties: Map<string, Property> = new Map();
     private loaded: boolean = false;
 
     constructor(path: fs.PathLike) {
         this.path = path;
     }
 
-    load = (force: boolean): void => {
-        if (this.loaded && !force) {
-            console.log(chalk.red(ALREADY_LOADED), this.path);
-            process.exit(1);
-        }
-
-        if (fs.existsSync(this.path)) {
-            console.log(chalk.red(FILE_DOESNT_EXIST), this.path);
-            process.exit(1);
-        }
-
-        // TODO: Implement .properties file deserializer
+    load = (): void => {
+        this.properties = handleLoad(this.path);
+        this.loaded = true;
     };
 
     save = (): void => {
@@ -44,22 +133,45 @@ export class PropertiesFile {
     /**
      * getProperty
      */
-    public getProperty(key: string): string {
-        if (!this.loaded) {
-            console.log(chalk.red(NOT_LOADED), this.path);
-        }
-
-        return this.properties[key];
+    public getProperty(key: string): Property | undefined {
+        return this.properties.get(key);
     }
 
     /**
      * setProperty
      */
-    public setProperty(key: string, value: string): void {
+    public setProperty(key: string, property: Property): void {
+        this.properties.set(key, property);
+    }
+
+    /**
+     * getPropertyValue
+     */
+    public getPropertyValue(key: string): string | undefined {
         if (!this.loaded) {
             console.log(chalk.red(NOT_LOADED), this.path);
         }
 
-        this.properties[key] = value;
+        return this.properties.get(key)?.value;
+    }
+
+    /**
+     * setPropertyValue
+     */
+    public setPropertyValue(
+        key: string,
+        value: string,
+        type: PropertyType = PropertyType.default
+    ): void {
+        if (!this.loaded) {
+            console.log(chalk.red(NOT_LOADED), this.path);
+        }
+
+        const prop = this.properties.get(key);
+        if (prop) {
+            prop.value = value;
+        } else {
+            this.properties.set(key, new Property(key, value, type));
+        }
     }
 }

--- a/tsconfig.build.json
+++ b/tsconfig.build.json
@@ -3,5 +3,5 @@
     "compilerOptions": {
         "outDir": "./build"
     },
-    "exclude": ["node_modules", "src/test"]
+    "exclude": ["node_modules", "src/test", "scripts"]
 }

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -8,5 +8,5 @@
         "skipLibCheck": true,
         "forceConsistentCasingInFileNames": true
     },
-    "exclude": ["node_modules"]
+    "exclude": ["node_modules", "scripts"]
 }


### PR DESCRIPTION
Forgive me @speleothem. I think the content here is sufficient enough for a 0.0.1 release, but I don't know if you we wanna deal with the refactor that'll be involved by pushing this into master

Key things to note that I implemented from our discussion today:
* mask all values of keys that contain pass  or auth
* secrets shouldn't be displayed by default in gpm property ls, show (secret) instead
* secrets are now still base64 encoded when put into gradle.properties
* gpm property get should return (secret) for secrets, and plaintext if the --decode flag is passed in
* fixed message saying `gpm property <command>` were operating on the current profile, even when the `--global` flag was passed in

Lmk if you catch anything else wrong functionality-wise, or if you think it's not ready to go out

